### PR TITLE
feat(item): add tooltip showing the amount of missing items

### DIFF
--- a/src/app/modules/common-components/amount-input/amount-input.component.html
+++ b/src/app/modules/common-components/amount-input/amount-input.component.html
@@ -1,6 +1,8 @@
 <mat-input-container>
     <input matInput type="number" #input min="{{min}}" max="{{max}}" [style.width]="getWidth()+'px'"
-           disabled="{{readonly}}" [value]="value">
+           disabled="{{readonly}}" [value]="value"
+           [matTooltip]="'Missing_crafts_amount' | translate:{'amount': missingAmount}"
+           matTooltipPosition="above" [matTooltipDisabled]="missingAmount === 0">
     <span matSuffix *ngIf="max">/{{max}}<span *ngIf="craftAmount" matTooltip="{{'Required_crafts_amount' | translate}}"
                                              matTooltipPosition="above"> ({{craftAmount}})</span></span>
 </mat-input-container>

--- a/src/app/modules/common-components/amount-input/amount-input.component.ts
+++ b/src/app/modules/common-components/amount-input/amount-input.component.ts
@@ -25,6 +25,10 @@ export class AmountInputComponent extends ComponentWithSubscriptions implements 
     @Input()
     max: number;
 
+    get missingAmount() {
+        return this.max - this.value
+    }
+
     @Input()
     craftAmount: number;
 

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -171,7 +171,7 @@
     "Hide_completed": "Verstecke komplettierte Reihen",
     "Your_comment": "Dein Kommentar",
     "Required_crafts_amount": "Menge an Herstellungen",
-    "Missing_crafts_amount": "{{amount}} to reach total",
+    "Missing_crafts_amount": "{{amount}} um Ziel-Menge zu erreichen",
     "Requires": "Erfordert",
     "Copy_item_name_to_clipboard": "Kopiere den Gegenstandsnamen zur Zwischenablage",
     "Item_name_copied": "{{itemname}} zur Zwischenablage hinzugefügt",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -171,6 +171,7 @@
     "Hide_completed": "Verstecke komplettierte Reihen",
     "Your_comment": "Dein Kommentar",
     "Required_crafts_amount": "Menge an Herstellungen",
+    "Missing_crafts_amount": "{{amount}} to reach total",
     "Requires": "Erfordert",
     "Copy_item_name_to_clipboard": "Kopiere den Gegenstandsnamen zur Zwischenablage",
     "Item_name_copied": "{{itemname}} zur Zwischenablage hinzugefügt",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -171,6 +171,7 @@
     "Hide_completed": "Hide completed rows",
     "Your_comment": "Your comment",
     "Required_crafts_amount": "Required amount of crafts",
+    "Missing_crafts_amount": "{{amount}} to reach total",
     "Requires": "Requires",
     "Copy_item_name_to_clipboard": "Copy item name to clipboard",
     "Item_name_copied": "{{itemname}} copied to clipboard",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -171,6 +171,7 @@
     "Hide_completed": "Masquer les éléments complétés",
     "Your_comment": "Votre commentaire",
     "Required_crafts_amount": "Nombre de crafts à faire",
+    "Missing_crafts_amount": "{{amount}} pour atteindre le total",
     "Requires": "Nécessite",
     "Copy_item_name_to_clipboard": "Copier le nom dans le press-papiers",
     "Item_name_copied": "{{itemname}} copié dans le presse-papiers",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -177,6 +177,7 @@
     "Hide_completed": "Hide completed rows",
     "Your_comment": "Your comment",
     "Required_crafts_amount": "Required amount of crafts",
+    "Missing_crafts_amount": "{{amount}} to reach total",
     "Requires": "Requires",
     "Copy_item_name_to_clipboard": "Copy item name to clipboard",
     "Item_name_copied": "{{itemname}} copied to clipboard",


### PR DESCRIPTION
Add tooltip that show the amount of missing items required to reach the total. The tooltip is shown
when hovering the native input field.

fix #145