### PR TITLE
fix: black social fabs (#221)

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -70,6 +70,7 @@
                         justify-content: center;
                         .social-fab {
                             font-size: 18px;
+                            color: white !important;
                             &.facebook {
                                 background: #3b5998;
                             }


### PR DESCRIPTION
Social fabs were black on teal themes. Now they're not. I hope.