### PR TITLE
fix: fixes missing linebreaks when copying macro from firefox

### DIFF
--- a/src/app/pages/simulator/components/macro-popup/macro-popup.component.html
+++ b/src/app/pages/simulator/components/macro-popup/macro-popup.component.html
@@ -5,7 +5,7 @@
     </mat-checkbox>
     <div class="macro">
         <pre *ngFor="let macroFragment of macro" class="macro-fragment">
-            <span class="macro-line" *ngFor="let line of macroFragment">{{line}}</span>
+            <span class="macro-line" *ngFor="let line of macroFragment">{{line}}<br></span>
         </pre>
     </div>
     <b>{{'SIMULATOR.Cross_class_setup' | translate}}</b>


### PR DESCRIPTION
Adding a linebreak element for each macro action fixes an firefox issue where linebreaks were not present when copying macros.