### PR TITLE
fix: missing linebreaks in cross-class setup macro

### DIFF
--- a/src/app/pages/simulator/components/macro-popup/macro-popup.component.html
+++ b/src/app/pages/simulator/components/macro-popup/macro-popup.component.html
@@ -12,7 +12,7 @@
     <mat-divider></mat-divider>
     <div class="macro">
         <pre class="macro-fragment">
-            <span class="macro-line" *ngFor="let line of aactionsMacro">{{line}}</span>
+            <span class="macro-line" *ngFor="let line of aactionsMacro">{{line}}<br></span>
         </pre>
     </div>
 </div>


### PR DESCRIPTION
Cross-class skill setup macro was also missing line-breaks when copying from Firefox. 