### PR TITLE
feat: apply stats to all crafts button

### DIFF
--- a/src/app/pages/profile/profile/profile.component.ts
+++ b/src/app/pages/profile/profile/profile.component.ts
@@ -26,7 +26,7 @@ import {combineLatest, of} from 'rxjs';
 })
 export class ProfileComponent extends PageComponent {
 
-    static craftingJobs = [
+    private craftingJobs: any[] = [
         {abbr: 'CRP', name: 'carpenter'},
         {abbr: 'BSM', name: 'blacksmith'},
         {abbr: 'ARM', name: 'armorer'},
@@ -69,7 +69,7 @@ export class ProfileComponent extends PageComponent {
                             });
                         }),
                         map(sets => sets.map(set => {
-                                const job = ProfileComponent.craftingJobs[set.jobId - 8];
+                                const job = this.craftingJobs[set.jobId - 8];
                                 if (job !== undefined) {
                                     set.abbr = job.abbr;
                                     set.name = job.name;
@@ -111,7 +111,7 @@ export class ProfileComponent extends PageComponent {
     }
 
     public openStatsPopup(set: GearSet): void {
-        this.dialog.open(StatsEditPopupComponent, {data: set});
+        this.dialog.open(StatsEditPopupComponent, {data: {set: set, jobs: this.craftingJobs.slice(0, 8)}});
     }
 
     changeCharacter(): void {

--- a/src/app/pages/profile/stats-edit-popup/stats-edit-popup.component.html
+++ b/src/app/pages/profile/stats-edit-popup/stats-edit-popup.component.html
@@ -23,11 +23,8 @@
     </div>
 </mat-dialog-content>
 <mat-dialog-actions>
-    <button mat-raised-button color="primary" (click)="saveSet(set)">{{'SIMULATOR.CONFIGURATION.Save_set' |
-        translate}}
-    </button>
-    <button mat-raised-button color="accent" (click)="resetSet(set)">{{'SIMULATOR.CONFIGURATION.Reset_set' |
-        translate}}
-    </button>
-    <button mat-button mat-dialog-close color="warn">{{'Cancel' | translate}}</button>
+    <button mat-raised-button color="primary" (click)="saveSet(set)">{{'COMMON.Save' | translate}}</button>
+    <button mat-raised-button color="primary" (click)="saveAllSets(set)">{{'PROFILE.Save_for_all' | translate}}</button>
+    <button mat-raised-button color="accent" (click)="resetSet(set)">{{'COMMON.Reset' | translate}}</button>
+    <button mat-raised-button mat-dialog-close color="warn">{{'Cancel' | translate}}</button>
 </mat-dialog-actions>

--- a/src/app/pages/profile/stats-edit-popup/stats-edit-popup.component.ts
+++ b/src/app/pages/profile/stats-edit-popup/stats-edit-popup.component.ts
@@ -14,9 +14,12 @@ export class StatsEditPopupComponent {
 
     public userData: AppUser;
 
-    constructor(private userService: UserService, @Inject(MAT_DIALOG_DATA) public set: GearSet,
+    public set: GearSet;
+
+    constructor(private userService: UserService, @Inject(MAT_DIALOG_DATA) public data: { set: GearSet, jobs: any[] },
                 private ref: MatDialogRef<StatsEditPopupComponent>) {
         this.userService.getUserData().pipe(first()).subscribe(data => this.userData = data);
+        this.set = this.data.set;
     }
 
     saveSet(set: GearSet): void {
@@ -25,6 +28,20 @@ export class StatsEditPopupComponent {
         // Then add this set to custom sets
         set.custom = true;
         this.userData.gearSets.push(set);
+        this.userService.set(this.userData.$key, this.userData).subscribe(() => {
+            this.ref.close();
+        });
+    }
+
+    saveAllSets(set: GearSet): void {
+        // Clear out all of the existing custom sets
+        this.userData.gearSets = [];
+
+        // Then create a custom set for each job using the provided set data
+        this.data.jobs.forEach((job, i) => {
+            this.userData.gearSets.push({ ...set, jobId: i + 8, abbr: job.abbr, name: job.name });
+        });
+
         this.userService.set(this.userData.$key, this.userData).subscribe(() => {
             this.ref.close();
         });

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -82,7 +82,7 @@
   "Lists": "Liste",
   "items": "Gegenstände",
   "Confirm": "Bestätigen",
-  "Cancel": "abbrechen",
+  "Cancel": "Abbrechen",
   "Edit": "bearbeiten",
   "Add_a_list": "Eine Liste hinzufügen",
   "List_name": "Listenname",
@@ -206,6 +206,7 @@
     "Patreon_email": "Patreon-Email",
     "Feature_requires_nickname": "Dieses Feature erfordert, dass du einen Nickname vergeben hast",
     "Contacts": "Kontakte",
+    "Save_for_all": "Für alle speichern",
     "New_contact": "User-ID des neuen Kontakts",
     "HELP": {
       "Welcome": "Willkommen zur Profilseite, hier kannst du dein Profil ansehen und bearbeiten.",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -217,6 +217,7 @@
     "Patreon_email": "Patreon Email",
     "Contacts": "Contacts",
     "New_contact": "New contact's user ID",
+    "Save_for_all": "Save for all",
     "HELP": {
       "Welcome": "Welcome to profile page, this is the place where you can see and edit your own profile.",
       "Edit": "By clicking on the edit icon, you can edit the character linked to your FFXIV Teamcraft account.",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -217,6 +217,7 @@
     "Patreon_email": "Email Patreon",
     "Contacts": "Contacts",
     "New_contact": "ID Utilisateur du nouveau contact",
+    "Save_for_all": "Sauvegarder pour tous",
     "HELP": {
       "Welcome": "Bienvenue sur la page de profil, qui vous permet de consulter et modifier votre profil.",
       "Edit": "En cliquant sur l'icône d'édition, vous pouvez changer le personnage FFXIV lié à votre compte FFXIV Teamcraft.",


### PR DESCRIPTION
Adds a "save for all" button, allowing users to quickly save the stats for one gearset across all gearsets. Resolves #418