### PR TITLE
feat(simulator): default consumables WIP

### DIFF
--- a/src/app/model/list/app-user.ts
+++ b/src/app/model/list/app-user.ts
@@ -5,6 +5,7 @@ import {Alarm} from '../../core/time/alarm';
 import {ListDetailsFilters} from '../other/list-details-filters';
 import {GearSet} from '../../pages/simulator/model/gear-set';
 import {AlarmGroup} from '../other/alarm-group';
+import {DefaultConsumables} from '../other/default-consumables';
 
 export class AppUser extends DataModel {
     name?: string;
@@ -44,6 +45,9 @@ export class AppUser extends DataModel {
     verified = false;
     // Evaluations for the commission board, by id of the person who gave the evaluation.
     ratings: { [index: string]: number } = {};
+    // Default consumables used for new rotations
+    @DeserializeAs(DefaultConsumables)
+    defaultConsumables?: DefaultConsumables;
 
     get rating(): number {
         if (Object.keys(this.ratings).length === 0) {

--- a/src/app/model/other/default-consumables.ts
+++ b/src/app/model/other/default-consumables.ts
@@ -1,0 +1,21 @@
+import {Consumable} from '../../pages/simulator/model/consumable';
+import {FreeCompanyAction} from '../../pages/simulator/model/free-company-action';
+import {DeserializeAs} from '@kaiu/serializer';
+
+export class DefaultConsumables {
+
+    @DeserializeAs(Consumable)
+    food: Consumable;
+
+    @DeserializeAs(Consumable)
+    medicine: Consumable;
+
+    @DeserializeAs([FreeCompanyAction])
+    freeCompanyActions: FreeCompanyAction[];
+
+    public constructor(food: Consumable, medicine: Consumable, freeCompanyActions: FreeCompanyAction[]) {
+        this.food = food;
+        this.medicine = medicine;
+        this.freeCompanyActions = freeCompanyActions;
+    }
+}

--- a/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -154,6 +154,14 @@
         </div>
         <div class="config-row">
             <h3>{{'SIMULATOR.CONFIGURATION.Consumables' | translate}}</h3>
+            <div class="save-button">
+                <button mat-mini-fab
+                        matTooltip="{{'SIMULATOR.CONFIGURATION.Save_consumables' | translate}}"
+                        color="accent"
+                        (click)="saveDefaultConsumables()">
+                    <mat-icon>save</mat-icon>
+                </button>
+            </div>
             <div class="consumables">
                 <div layout="row">
                     <div class="foods" flex="50">

--- a/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -16,6 +16,7 @@ import {HtmlToolsService} from '../../../../core/tools/html-tools.service';
 import {EffectiveBuff} from '../../model/effective-buff';
 import {Buff} from 'app/pages/simulator/model/buff.enum';
 import {Consumable} from '../../model/consumable';
+import {DefaultConsumables} from '../../../../model/other/default-consumables';
 import {foods} from '../../../../core/data/sources/foods';
 import {medicines} from '../../../../core/data/sources/medicines';
 import {freeCompanyActions} from '../../../../core/data/sources/free-company-actions';
@@ -395,6 +396,20 @@ export class SimulatorComponent implements OnInit, OnDestroy {
             this.selectedSet = res.set;
             this.applyStats(res.set, res.levels, false);
         });
+
+        this.actions$.subscribe(actions => {
+            // Set the default consumables, overriden later if this is an existing rotation
+            if (actions.length === 0) {
+                this.userService.getUserData().pipe(
+                    tap(user => {
+                        const defaultConsumables = user.defaultConsumables;
+                        this._selectedFood = defaultConsumables.food;
+                        this._selectedMedicine = defaultConsumables.medicine;
+                        this._selectedFreeCompanyActions = defaultConsumables.freeCompanyActions;
+                    })
+                ).subscribe();
+            }
+        });
     }
 
     importRotation(): void {
@@ -634,6 +649,12 @@ export class SimulatorComponent implements OnInit, OnDestroy {
         // Then add this set to custom sets
         set.custom = true;
         this.userData.gearSets.push(set);
+        this.userService.set(this.userData.$key, this.userData).subscribe();
+    }
+
+    saveDefaultConsumables(): void {
+        this.userData.defaultConsumables =
+            new DefaultConsumables(this._selectedFood, this._selectedMedicine, this._selectedFreeCompanyActions);
         this.userService.set(this.userData.$key, this.userData).subscribe();
     }
 

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -472,6 +472,7 @@
       "Food": "Wähle ein Gericht",
       "Medicine": "Wähle eine Arznei",
       "Action": "Wählen Sie freie Firmenaktionen",
+      "Save_consumables": "Speichern Sie diese Verbrauchsmaterialien als Standard",
       "STATS": {
         "CP": "HP",
         "Craftsmanship": "Kunstfertigkeit",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -505,6 +505,7 @@
       "Action": "Choose free company actions",
       "Save_set": "Save these stats for this job",
       "Reset_set": "Reset these stats",
+      "Save_consumables": "Save these consumables as default",
       "STATS": {
         "CP": "CP",
         "Craftsmanship": "Craftsmanship",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -505,6 +505,7 @@
       "Action": "Choisir les bienfaits de compagnie libre",
       "Save_set": "Sauvegarder les stats pour cette classe",
       "Reset_set": "Remettre les stats à 0",
+      "Save_consumables": "Sauvegarder en tant que consommables par défaut",
       "STATS": {
         "CP": "PS",
         "Craftsmanship": "Habileté",


### PR DESCRIPTION
Adds the ability to save a rotation's consumables as default. When a new
rotation is created, these consumables will automatically be populated.

TODO: Currently setting defaults for every single rotation. :(

Resolves #426