### PR TITLE
feat: add specialist stat bonus

### DIFF
--- a/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -531,6 +531,7 @@ export class SimulatorComponent implements OnInit, OnDestroy {
         let bonusFromFood = 0;
         let bonusFromMedicine = 0;
         let bonusFromFreeCompanyAction = 0;
+        let bonusFromSpecialist = 0;
 
         if (this._selectedFood !== undefined) {
             const foodBonus = this._selectedFood.getBonus(bonusType);
@@ -555,7 +556,11 @@ export class SimulatorComponent implements OnInit, OnDestroy {
             bonusFromFreeCompanyAction = this.getFreeCompanyActionValue(bonusType);
         }
 
-        return bonusFromFood + bonusFromMedicine + bonusFromFreeCompanyAction;
+        if (this.selectedSet.specialist && bonusType !== <BonusType>'CP') {
+            bonusFromSpecialist = 20;
+        }
+
+        return bonusFromFood + bonusFromMedicine + bonusFromFreeCompanyAction + bonusFromSpecialist;
     }
 
     getFreeCompanyActionValue(bonusType: BonusType): number {


### PR DESCRIPTION
When a player is a specialist, they receive a bonus of 20 to both craftsmanship and control. This feature will reflect that bonus in the crafting simulator.