### PR TITLE
feat(simulator): add custom delay offset to apply to macro

### DIFF
--- a/src/app/pages/simulator/components/macro-popup/macro-popup.component.html
+++ b/src/app/pages/simulator/components/macro-popup/macro-popup.component.html
@@ -7,10 +7,16 @@
         <mat-checkbox [(ngModel)]="fixedEcho" [disabled]="!addEcho" (ngModelChange)="generateMacros()">
             {{'SIMULATOR.Fixed_notification_number' | translate}}
         </mat-checkbox>
-        <mat-form-field>
-            <input type="number" [(ngModel)]="echoSeNumber" [disabled]="!addEcho" (ngModelChange)="generateMacros()"
-                   placeholder="{{'SIMULATOR.Starting_echo_number' | translate}}" matInput>
-        </mat-form-field>
+        <div class="fields">
+            <mat-form-field>
+                <input type="number" min="1" max="16" [(ngModel)]="echoSeNumber" [disabled]="!addEcho"
+                    (ngModelChange)="generateMacros()" placeholder="{{'SIMULATOR.Starting_echo_number' | translate}}" matInput>
+            </mat-form-field>
+            <mat-form-field>
+                <input type="number" min="0" max="100" [(ngModel)]="extraWait"
+                    (ngModelChange)="generateMacros()" placeholder="{{'SIMULATOR.Extra_wait' | translate}}" matInput>
+            </mat-form-field>
+        </div>
     </div>
     <div class="macro">
         <pre *ngFor="let macroFragment of macro" class="macro-fragment">

--- a/src/app/pages/simulator/components/macro-popup/macro-popup.component.scss
+++ b/src/app/pages/simulator/components/macro-popup/macro-popup.component.scss
@@ -1,8 +1,17 @@
 .content {
-    padding-top: 15px;
     .config {
         display: flex;
         flex-direction: column;
+        .mat-checkbox {
+            margin-bottom: 10px;
+        }
+        .fields {
+            flex-direction: row;
+            .mat-form-field {
+                width: 50%;
+                padding-right: 10px;
+            }
+        }
     }
     .macro-fragment {
         display: flex;

--- a/src/app/pages/simulator/components/macro-popup/macro-popup.component.ts
+++ b/src/app/pages/simulator/components/macro-popup/macro-popup.component.ts
@@ -24,6 +24,8 @@ export class MacroPopupComponent implements OnInit {
 
     public fixedEcho = false;
 
+    public extraWait = 0;
+
     constructor(@Inject(MAT_DIALOG_DATA) private data: { rotation: CraftingAction[], job: CraftingJob }, private l12n: LocalizedDataService,
                 private i18n: I18nToolsService) {
     }
@@ -47,13 +49,13 @@ export class MacroPopupComponent implements OnInit {
                     this.aactionsMacro.push(`/aaction ${actionName}`);
                 }
             }
-            macroFragment.push(`/ac ${actionName} <wait.${action.getWaitDuration()}>`);
+            macroFragment.push(`/ac ${actionName} <wait.${action.getWaitDuration() + this.extraWait}>`);
             if (macroFragment.length === 14 && this.addEcho) {
                 let seNumber: number;
                 if (this.fixedEcho) {
                     seNumber = this.echoSeNumber;
                 } else {
-                    seNumber = this.echoSeNumber - 1 + this.macro.length;
+                    seNumber = Math.min(this.echoSeNumber - 1 + this.macro.length, 16);
                 }
                 macroFragment.push(`/echo Macro #${this.macro.length} finished <se.${seNumber}>`);
             }
@@ -63,7 +65,7 @@ export class MacroPopupComponent implements OnInit {
             if (this.fixedEcho) {
                 seNumber = this.echoSeNumber;
             } else {
-                seNumber = this.echoSeNumber + this.macro.length;
+                seNumber = Math.min(this.echoSeNumber + this.macro.length, 16);
             }
             this.macro[this.macro.length - 1].push(`/echo Craft finished <se.${seNumber}>`)
         }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -408,6 +408,8 @@
     "Not_found": "Seite nicht gefunden"
   },
   "SIMULATOR": {
+    "Starting_echo_number": "Mitteilung #",
+    "Extra_wait": "Extra wartezeit",
     "Import_macro": "Von Spiel-Makro importieren",
     "Ingame_macro": "Spiel-Makro",
     "Min_stats": "Minimale Werte",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -440,6 +440,7 @@
   "SIMULATOR": {
     "Fixed_notification_number": "Fixed notification",
     "Starting_echo_number": "Notification #",
+    "Extra_wait": "Extra wait",
     "Import_macro": "Import from ingame macro",
     "Ingame_macro": "Ingame macro",
     "Min_stats": "Minimum stats",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -440,6 +440,7 @@
   "SIMULATOR": {
     "Fixed_notification_number": "Notification fixe",
     "Starting_echo_number": "Numéro de référence",
+    "Extra_wait": "Temps d'attente supp.",
     "Import_macro": "Importer une macro du jeu",
     "Ingame_macro": "Macro",
     "Min_stats": "Stats minimum",


### PR DESCRIPTION
Adds a numeric input to the in-game macro generator that allows users to specify an extra wait value. This value is added to all occurrences of <wait.x> in the macro. Also adds limits to the notification # to keep it from going out of bounds.

Resolves #428