### PR TITLE
fix: hidden action tooltips in simulator

### DIFF
--- a/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -426,6 +426,7 @@
                             [failed]="!step.success"
                             (onDragStart)="tooltipsDisabled = true"
                             (onDragEnd)="tooltipsDisabled = false"
+                            (onDrop)="tooltipsDisabled = false"
                             [tooltipDisabled]="tooltipsDisabled"></app-action>
                 <div class="end-drag-zone" droppable
                      dragOverClass="drag-over"

--- a/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -547,6 +547,7 @@ export class SimulatorComponent implements OnInit, OnDestroy {
         }
         this.actions$.next(actions);
         this.markAsDirty();
+        this.tooltipsDisabled = false;
     }
 
     getBonusValue(bonusType: BonusType, baseValue: number): number {


### PR DESCRIPTION
Fixes #450 where tooltips would remain hidden after reordering actions.
The bug appears to be a result of the rotation actions having both the
draggable and droppable directives. In this case, onDrop appears to
fire while onDragEnd does not.