### PR TITLE
fix: selected job not saved in custom rotation

### DIFF
--- a/src/app/pages/simulator/components/custom-simulator-page/custom-simulator-page.component.html
+++ b/src/app/pages/simulator/components/custom-simulator-page/custom-simulator-page.component.html
@@ -26,7 +26,8 @@
     </mat-expansion-panel>
 
     <app-simulator [recipe]="recipe" [inputGearSet]="stats" [actions]="actions"
-                   [customMode]="true" [canSave]="canSave"
+                   [customMode]="true" [canSave]="canSave" [selectedFood]="selectedFood"
+                   [selectedMedicine]="selectedMedicine" [selectedFreeCompanyActions]="selectedFreeCompanyActions"
                    (onsave)="save($event)" [authorId]="authorId" [rotation]="rotation"></app-simulator>
 
 </div>

--- a/src/app/pages/simulator/components/custom-simulator-page/custom-simulator-page.component.ts
+++ b/src/app/pages/simulator/components/custom-simulator-page/custom-simulator-page.component.ts
@@ -8,6 +8,8 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {CraftingActionsRegistry} from '../../model/crafting-actions-registry';
 import {CraftingAction} from '../../model/actions/crafting-action';
 import {GearSet} from '../../model/gear-set';
+import {Consumable} from '../../model/consumable';
+import {FreeCompanyAction} from '../../model/free-company-action';
 import {filter, first, map, mergeMap} from 'rxjs/operators';
 import {CraftingRotation} from '../../../../model/other/crafting-rotation';
 
@@ -33,6 +35,12 @@ export class CustomSimulatorPageComponent {
     public stats: GearSet;
 
     public canSave = false;
+
+    public selectedFood: Consumable;
+
+    public selectedMedicine: Consumable;
+
+    public selectedFreeCompanyActions: FreeCompanyAction[];
 
     public notFound = false;
 
@@ -60,6 +68,9 @@ export class CustomSimulatorPageComponent {
             this.actions = this.registry.deserializeRotation(res.rotation.rotation);
             this.stats = res.rotation.stats;
             this.authorId = res.rotation.authorId;
+            this.selectedFood = res.rotation.consumables.food;
+            this.selectedMedicine = res.rotation.consumables.medicine;
+            this.selectedFreeCompanyActions = res.rotation.freeCompanyActions;
             this.canSave = res.userId === res.rotation.authorId;
             this.rotation = res.rotation;
         }, () => this.notFound = true);
@@ -78,6 +89,8 @@ export class CustomSimulatorPageComponent {
                     result.authorId = rotation.authorId;
                     result.description = '';
                     result.name = rotation.name;
+                    result.consumables = rotation.consumables;
+                    result.freeCompanyActions = rotation.freeCompanyActions;
                     if (result.$key === undefined || !this.canSave) {
                         result.authorId = userId;
                         // If the rotation has no key, it means that it's a new one, so let's create a rotation entry in the database.

--- a/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -89,8 +89,7 @@
             <div *ngIf="gearsets$ | async as gearsets">
                 <mat-select *ngIf="customMode"
                             [placeholder]="'SIMULATOR.CONFIGURATION.Select_job' | translate"
-                            [(ngModel)]="selectedSet"
-                            (ngModelChange)="applyStats(selectedSet, levels)">
+                            [(ngModel)]="selectedSet" [compareWith]="compareGearSetsFn">
                     <mat-option *ngFor="let set of gearsets" [value]="set">
                         {{set.jobId | jobName | i18n}} (ilvl {{set.ilvl}}) <span *ngIf="set.specialist">({{'SIMULATOR.Specialist' | translate}})</span>
                     </mat-option>

--- a/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -395,7 +395,7 @@ export class SimulatorComponent implements OnInit, OnDestroy {
                 levels: <CrafterLevels>gearsets.map(set => set.level)
             };
         }).subscribe(res => {
-            this.selectedSet = res.set;
+            this.selectedSet = this.selectedSet || res.set;
             this.applyStats(res.set, res.levels, false);
         });
 
@@ -410,9 +410,10 @@ export class SimulatorComponent implements OnInit, OnDestroy {
                 this.userService.getUserData().pipe(
                     tap(user => {
                         const defaultConsumables = (user.defaultConsumables || <DefaultConsumables>{});
-                        this._selectedFood = defaultConsumables.food;
-                        this._selectedMedicine = defaultConsumables.medicine;
-                        this._selectedFreeCompanyActions = defaultConsumables.freeCompanyActions;
+                        this._selectedFood = this._selectedFood || defaultConsumables.food;
+                        this._selectedMedicine = this._selectedMedicine || defaultConsumables.medicine;
+                        this._selectedFreeCompanyActions = this._selectedFreeCompanyActions ||
+                            defaultConsumables.freeCompanyActions;
                     })
                 ).subscribe();
             }
@@ -611,6 +612,10 @@ export class SimulatorComponent implements OnInit, OnDestroy {
 
     compareFreeCompanyActionsFn(action1: FreeCompanyAction, action2: FreeCompanyAction): boolean {
         return action1 && action2 && action1.actionId === action2.actionId;
+    }
+
+    compareGearSetsFn(set1: GearSet, set2: GearSet): boolean {
+        return set1 && set2 && set1.jobId === set2.jobId;
     }
 
     applyStats(set: GearSet, levels: CrafterLevels, markDirty = true): void {


### PR DESCRIPTION
Fixes custom rotations so that the selected job saves properly.
Previously, this was being overridden in the simulator's ngOnInit.
Also fixes consumables and actions which were not being saved at all.

Fixes #455