### PR TITLE
feat: quick commission button on search results

### DIFF
--- a/src/app/pages/commission-board/commission-creation-popup/commission-creation-popup.component.html
+++ b/src/app/pages/commission-board/commission-creation-popup/commission-creation-popup.component.html
@@ -1,6 +1,6 @@
 <h3 mat-dialog-title>{{'COMMISSION_BOARD.New_commission' | translate: {listName: list.name} }}</h3>
 <div mat-dialog-content>
-    <p>
+    <p *ngIf="displayWarning">
         {{'COMMISSION_BOARD.New_commission_warning' | translate}}
     </p>
     <mat-form-field>

--- a/src/app/pages/commission-board/commission-creation-popup/commission-creation-popup.component.ts
+++ b/src/app/pages/commission-board/commission-creation-popup/commission-creation-popup.component.ts
@@ -18,9 +18,16 @@ export class CommissionCreationPopupComponent {
 
     public price = 0;
 
-    constructor(@Inject(MAT_DIALOG_DATA) public list: List, private router: Router, private commissionService: CommissionService,
+    public list: List;
+
+    public displayWarning = false;
+
+    constructor(@Inject(MAT_DIALOG_DATA) public data: { list: List, displayWarning?: boolean },
+                private router: Router, private commissionService: CommissionService,
                 private ref: MatDialogRef<CommissionCreationPopupComponent>, private userService: UserService,
                 private listService: ListService) {
+        this.list = data.list;
+        this.displayWarning = data.displayWarning;
     }
 
     public createCommission(): void {

--- a/src/app/pages/commission-board/commission-panel/commission-panel.component.ts
+++ b/src/app/pages/commission-board/commission-panel/commission-panel.component.ts
@@ -60,7 +60,15 @@ export class CommissionPanelComponent implements OnInit {
                                 list.authorId = this.commission.authorId;
                                 return list;
                             }),
-                            mergeMap(list => this.listService.set(list.$key, list))
+                            mergeMap(list => {
+                                if (list.ephemeral) {
+                                    // Quick commission lists are deleted
+                                    return this.listService.remove(list.$key)
+                                } else {
+                                    // Normal lists are retained
+                                    return this.listService.set(list.$key, list)
+                                }
+                            })
                         );
                 }),
                 mergeMap(() => {

--- a/src/app/pages/list/list-details/list-details.component.ts
+++ b/src/app/pages/list/list-details/list-details.component.ts
@@ -142,7 +142,7 @@ export class ListDetailsComponent extends ComponentWithSubscriptions implements 
     }
 
     public createCommission(list: List): void {
-        this.dialog.open(CommissionCreationPopupComponent, {data: list});
+        this.dialog.open(CommissionCreationPopupComponent, { data: { list: list, displayWarning: true } });
     }
 
     public getLink(): string {

--- a/src/app/pages/recipes/recipes/recipes.component.html
+++ b/src/app/pages/recipes/recipes/recipes.component.html
@@ -226,6 +226,11 @@
                         matTooltipPosition="above">
                     <mat-icon>access_time</mat-icon>
                 </button>
+                <button mat-icon-button (click)="createCommission(item, amount.value)"
+                        matTooltip="{{'COMMISSION_BOARD.Create_commission' | translate}}"
+                        matTooltipPosition="above">
+                    <mat-icon>drafts</mat-icon>
+                </button>
                 <button mat-icon-button
                         *ngIf="item.recipeId !== undefined"
                         matTooltip="{{'SIMULATOR.Simulate_tooltip' | translate}}"

--- a/src/app/pages/recipes/recipes/recipes.component.ts
+++ b/src/app/pages/recipes/recipes/recipes.component.ts
@@ -315,11 +315,15 @@ export class RecipesComponent extends PageComponent implements OnInit {
     }
 
     quickList(recipe: Recipe, amount: string, collectible: boolean): void {
-        this.subscriptions.push(this.createQuickList(recipe, amount, collectible).subscribe(list => {
-            this.listService.getRouterPath(list.$key).subscribe(path => {
+        this.subscriptions.push(this.createQuickList(recipe, amount, collectible)
+            .pipe(
+                mergeMap(list => {
+                    return this.listService.getRouterPath(list.$key);
+                })
+            ).subscribe(path => {
                 this.router.navigate(path);
-            });
-        }));
+            })
+        );
     }
 
     /**


### PR DESCRIPTION
Adds a commission button to the Items search that allows a user to
quickly create a commission for that single item. Updates the commission
dialog to allow suppression of the list warning since it does not apply
in this case. Updates the flow for deleting a commission so that the
list is destroyed if it was a quick commission.

Resolves #490