### PR TITLE
feat: show levels for retainer ventures

### DIFF
--- a/src/app/core/api/garland-tools.service.ts
+++ b/src/app/core/api/garland-tools.service.ts
@@ -1,6 +1,8 @@
 import {Injectable} from '@angular/core';
 import {GarlandToolsData} from '../../model/list/garland-tools-data';
 import {Item} from '../../model/garland-tools/item';
+import {JobCategory} from '../../model/garland-tools/job-category';
+import {Venture} from '../../model/garland-tools/venture';
 import {NgSerializerService} from '@kaiu/ng-serializer';
 import {HttpClient} from '@angular/common/http';
 
@@ -65,6 +67,15 @@ export class GarlandToolsService {
     }
 
     /**
+     * Gets details for a given job category in garlandtools data.
+     * @param {number} id
+     * @returns {JobCategory}
+     */
+    getJobCategory(id: number): JobCategory {
+        return this.gt.jobCategories[id];
+    }
+
+    /**
      * Gets a list of category ids for a given job, useful for search filters.
      * @param {number[]} jobs
      * @returns {number[]}
@@ -82,5 +93,27 @@ export class GarlandToolsService {
             })
             // Then we convert the string array to a number array
             .map(key => +key);
+    }
+
+    /**
+     * Gets a list of ventures based on their ids in garlandtools data.
+     * @param {number[]} ids
+     * @returns {Venture[]}
+     */
+    getVentures(ids: number[]): Venture[] {
+        return ids.map(id => {
+            const venture = this.gt.ventureIndex[id];
+            const category = this.getJobCategory(venture.jobs);
+
+            // Convert the jobCategory (jobs) to a job id
+            if (category.jobs.length > 1) {
+                // Custom id to represent the DoW/M "hybrid" job
+                venture.job = 100;
+            } else {
+                venture.job = category.jobs[0];
+            }
+
+            return venture;
+        });
     }
 }

--- a/src/app/model/garland-tools/job-category.ts
+++ b/src/app/model/garland-tools/job-category.ts
@@ -1,0 +1,5 @@
+export interface JobCategory {
+    id: number;
+    name: string;
+    jobs: number[];
+}

--- a/src/app/model/garland-tools/venture.ts
+++ b/src/app/model/garland-tools/venture.ts
@@ -1,0 +1,12 @@
+export interface Venture {
+    id: number;
+    job: number;
+    jobs: number;
+    lvl: number;
+    cost: number;
+    minutes: number;
+    gathering?: number[];
+    ilvl?: number[];
+    amounts: number[];
+    name?: string;
+}

--- a/src/app/model/list/garland-tools-data.ts
+++ b/src/app/model/list/garland-tools-data.ts
@@ -1,3 +1,6 @@
+import {JobCategory} from '../garland-tools/job-category';
+import {Venture} from '../garland-tools/venture';
+
 export interface GarlandToolsData {
     patch: any;
     xp: number[];
@@ -19,7 +22,8 @@ export interface GarlandToolsData {
         ingredients: any[]
     };
     instanceTypes: string[];
-    jobCategories: any;
+    jobCategories: JobCategory[];
+    ventureIndex: Venture[];
     bell: {
         nodes: any[]
     };

--- a/src/app/modules/item/item/item.component.ts
+++ b/src/app/modules/item/item/item.component.ts
@@ -622,7 +622,7 @@ export class ItemComponent extends ComponentWithSubscriptions implements OnInit,
 
     public openVentureDetails(item: ListRow): void {
         this.dialog.open(VentureDetailsPopupComponent, {
-            data: item
+            data: item.ventures
         });
     }
 

--- a/src/app/modules/item/venture-details-popup/venture-details-popup.component.html
+++ b/src/app/modules/item/venture-details-popup/venture-details-popup.component.html
@@ -1,9 +1,14 @@
-<h2 mat-dialog-title>{{data.id | itemName | i18n}}</h2>
-<div mat-dialog-content>
+<div mat-dialog-content class="content">
     <mat-list>
-        <mat-list-item *ngFor="let venture of data.ventures">
-            <mat-icon mat-list-icon>location_on</mat-icon>
-            <b mat-line>{{venture | ventureName | i18n}}</b>
+        <mat-list-item *ngFor="let venture of ventures" class="venture">
+            <h3 mat-line class="title">
+                Lv. {{venture.lvl}}
+                {{venture.name ? (venture.id | ventureName | i18n) : (venture.job | jobAbbr:DOWM | i18n)}}
+            </h3>
+            <div mat-line *ngFor="let amount of ventureAmounts(venture)" class="amount">
+                <div>{{amount.name | translate}} {{amount.stat}}:</div>
+                <div>x{{amount.quantity}}</div>
+            </div>
         </mat-list-item>
     </mat-list>
 </div>

--- a/src/app/modules/item/venture-details-popup/venture-details-popup.component.scss
+++ b/src/app/modules/item/venture-details-popup/venture-details-popup.component.scss
@@ -1,0 +1,20 @@
+.content {
+    margin-top: -16px;
+    margin-bottom: -16px;
+    min-width: 250px;
+}
+
+.mat-line.title {
+    font-weight: bold;
+    margin-bottom: 10px;
+}
+
+.mat-line.amount {
+    display: flex;
+    div {
+        flex: 1;
+        &:nth-child(2) {
+            text-align: right;
+        }
+    }
+}

--- a/src/app/modules/item/venture-details-popup/venture-details-popup.component.ts
+++ b/src/app/modules/item/venture-details-popup/venture-details-popup.component.ts
@@ -1,14 +1,31 @@
-import {Component, Inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
 import {MAT_DIALOG_DATA} from '@angular/material';
+import {GarlandToolsService} from 'app/core/api/garland-tools.service';
+import {Venture} from 'app/model/garland-tools/venture';
 
 @Component({
     selector: 'app-venture-details-popup',
     templateUrl: './venture-details-popup.component.html',
-    styleUrls: ['./venture-details-popup.component.scss']
+    styleUrls: ['./venture-details-popup.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class VentureDetailsPopupComponent {
 
-    constructor(@Inject(MAT_DIALOG_DATA) public data: any) {
+    DOWM = { 'en': 'Disciple of War/Magic', 'ja': '戦闘職', 'de': 'Krieger/Magier', 'fr': 'Combattant' };
+
+    public ventures: Venture[];
+
+    constructor(@Inject(MAT_DIALOG_DATA) public data: any, private gt: GarlandToolsService) {
+        this.ventures = gt.getVentures(data);
     }
 
+    ventureAmounts(venture: Venture): any[] {
+        if (venture.amounts !== undefined) {
+            const stats = venture.ilvl || venture.gathering;
+            const name = venture.ilvl ? 'filters/ilvl' : 'Gathering';
+            return stats.map((stat, i) => ({ name: name, stat: stat, quantity: venture.amounts[i]}));
+        } else {
+            return [];
+        }
+    }
 }

--- a/src/app/pipes/job-abbr.pipe.ts
+++ b/src/app/pipes/job-abbr.pipe.ts
@@ -7,8 +7,9 @@ import {I18nName} from '../model/list/i18n-name';
 })
 export class JobAbbrIconPipe implements PipeTransform {
 
+
     transform(id: number, fallback?: string): I18nName {
-        return jobAbbrs[id];
+        return jobAbbrs[id] || fallback;
     }
 
 }


### PR DESCRIPTION
Adds significantly more details to the venture details popup, including
required level, venture name, and amount of items yielded. Introduces
new JobCategory and Venture interfaces for the Garland Tools data, as
well as functions for retrieving this information from the GT service.

Resolves #315