### PR TITLE
fix: list recipe simulator links

### DIFF
--- a/src/app/modules/item/item/item.component.html
+++ b/src/app/modules/item/item/item.component.html
@@ -167,11 +167,11 @@
         <div class="classes">
             <div *ngIf="recipe">
                 <mat-menu #simulatorMenu="matMenu">
-                    <button mat-menu-item routerLink="/simulator/{{item.id}}">{{'SIMULATOR.New_rotation' | translate}}
+                    <button mat-menu-item routerLink="/simulator/{{item.id}}/{{item.recipeId}}">{{'SIMULATOR.New_rotation' | translate}}
                     </button>
                     <button mat-menu-item
                             *ngFor="let rotation of rotations$ | async"
-                            routerLink="/simulator/{{item.id}}/{{rotation.$key}}">{{rotation.getName()}}
+                            routerLink="/simulator/{{item.id}}/{{item.recipeId}}/{{rotation.$key}}">{{rotation.getName()}}
                     </button>
                     <mat-divider></mat-divider>
                     <a *ngIf="getCraft(item.recipeId) as craft"


### PR DESCRIPTION
Adds missing recipeId parameter to simulator links for list items,
ensuring that the recipe with the proper job is loaded. This bug
was an extension of #401 that applied to the simulator links on the
final products.