### PR TITLE
feat: add HQ material cost to total price popup

### DIFF
--- a/src/app/model/list/list.ts
+++ b/src/app/model/list/list.ts
@@ -388,7 +388,6 @@ export class List extends DataWithPermissions {
     hasAllBaseIngredients(item: ListRow, amount = item.amount): boolean {
         // If it's not a craft, break recursion
         if (item.craftedBy === undefined || item.craftedBy.length === 0 || item.requires === undefined) {
-            console.log(item.id, item.done, amount, item.amount);
             // Simply return the amount of the item being equal to the amount needed.
             return item.done >= amount;
         }

--- a/src/app/pages/list/total-price-popup/total-price-popup.component.html
+++ b/src/app/pages/list/total-price-popup/total-price-popup.component.html
@@ -6,7 +6,12 @@
                  mat-list-avatar>
             <app-item-icon [item]="{icon: row.currencyIcon, id: row.currencyId}" mat-list-avatar
                            *ngIf="row.currencyId > -1"></app-item-icon>
-            <p matLine>{{row.amount}}</p>
+                       <p matLine>
+                           {{row.costs[0]}}
+                           <span *ngIf="row.costs.length > 1">
+                               (NQ) - {{row.costs[1]}} (HQ)
+                           </span>
+                       </p>
         </mat-list-item>
     </mat-list>
 </div>

--- a/src/app/pages/list/total-price-popup/total-price-popup.component.scss
+++ b/src/app/pages/list/total-price-popup/total-price-popup.component.scss
@@ -1,0 +1,3 @@
+h3.mat-dialog-title {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
Displays a cost range where applicable, from the cost for all NQ mats to
the cost for all HQ mats. A single cost value is displayed for materials
that cannot be purchased as HQ. Fixed up change detection and console log.

Resolves #442