### PR TITLE
refactor: list and simulator tweaks

### DIFF
--- a/src/app/modules/item/venture-details-popup/venture-details-popup.component.ts
+++ b/src/app/modules/item/venture-details-popup/venture-details-popup.component.ts
@@ -20,12 +20,16 @@ export class VentureDetailsPopupComponent {
     }
 
     ventureAmounts(venture: Venture): any[] {
+        let amounts = [];
+
         if (venture.amounts !== undefined) {
             const stats = venture.ilvl || venture.gathering;
             const name = venture.ilvl ? 'filters/ilvl' : 'Gathering';
-            return stats.map((stat, i) => ({ name: name, stat: stat, quantity: venture.amounts[i]}));
-        } else {
-            return [];
+            if (stats) {
+                amounts = stats.map((stat, i) => ({ name: name, stat: stat, quantity: venture.amounts[i]}));
+            }
         }
+
+        return amounts;
     }
 }

--- a/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -245,7 +245,7 @@
                 </a>
                 <mat-card-title *ngIf="itemId !== undefined">
                     {{itemId | itemName | i18n}}
-                    <button mat-icon-button (click)="changeRecipe()" *ngIf="rotation !== undefined && !dirty">
+                    <button mat-icon-button (click)="changeRecipe()" [disabled]="rotation === undefined || dirty">
                         <mat-icon>swap_horiz</mat-icon>
                     </button>
                 </mat-card-title>


### PR DESCRIPTION
Updates the venture amounts logic to handle cases where the amounts are present in the GT API but the required stats are not. Previously this failed and the venture level/job were not displayed.

Updates the change recipe button in the simulator to disable instead of being hidden.