### PR TITLE
fix: remove ephemeral flag from quick commissions

### DIFF
--- a/src/app/pages/commission-board/commission-panel/commission-panel.component.ts
+++ b/src/app/pages/commission-board/commission-panel/commission-panel.component.ts
@@ -61,13 +61,7 @@ export class CommissionPanelComponent implements OnInit {
                                 return list;
                             }),
                             mergeMap(list => {
-                                if (list.ephemeral) {
-                                    // Quick commission lists are deleted
-                                    return this.listService.remove(list.$key)
-                                } else {
-                                    // Normal lists are retained
-                                    return this.listService.set(list.$key, list)
-                                }
+                                return this.listService.set(list.$key, list);
                             })
                         );
                 }),

--- a/src/app/pages/recipes/recipes/recipes.component.ts
+++ b/src/app/pages/recipes/recipes/recipes.component.ts
@@ -409,7 +409,7 @@ export class RecipesComponent extends PageComponent implements OnInit {
     }
 
     createCommission(recipe: Recipe, amount: string): void {
-        this.subscriptions.push(this.createQuickList(recipe, amount, false).subscribe(list => {
+        this.subscriptions.push(this.createQuickList(recipe, amount, false, false).subscribe(list => {
             this.dialog.open(CommissionCreationPopupComponent, { data: { list: list } });
         }));
     }
@@ -418,11 +418,11 @@ export class RecipesComponent extends PageComponent implements OnInit {
         return RecipesHelpComponent;
     }
 
-    private createQuickList(recipe: Recipe, amount: string, collectible: boolean): Observable<List> {
+    private createQuickList(recipe: Recipe, amount: string, collectible: boolean, ephemeral = true): Observable<List> {
         const list = new List();
         ga('send', 'event', 'List', 'creation');
         list.name = this.i18n.getName(this.localizedData.getItem(recipe.itemId));
-        list.ephemeral = true;
+        list.ephemeral = ephemeral;
         return this.resolver.addToList(recipe.itemId, list, recipe.recipeId, +amount, collectible)
             .pipe(
                 switchMap((l) => {


### PR DESCRIPTION
This flag was causing the list to be deleted when it was completed by
the applicant, preventing the commission from being archived. This fix
removes the ephemeral flag from quick commission lists and the extra
logic associated with it. Deleted quick commissions will now revert
to regular lists instead of being deleted.