### PR TITLE
refactor: list and workshop button order

### DIFF
--- a/src/app/modules/common-components/list-panel/list-panel.component.html
+++ b/src/app/modules/common-components/list-panel/list-panel.component.html
@@ -27,6 +27,11 @@
                 </mat-panel-description>
             </div>
             <div class="buttons" *ngIf="!isMobile()">
+                <button mat-icon-button *ngIf="buttons" routerLink="/list/{{list.$key}}"
+                        matTooltip="{{'LIST.BUTTONS.Open' | translate}}" matTooltipPosition="above"
+                        (click)="$event.stopPropagation()">
+                    <mat-icon>playlist_play</mat-icon>
+                </button>
                 <app-comments-button *ngIf="list.public" [name]="list.name" [list]="list"
                                      [isOwnList]="list.authorId === authorUid"
                                      color="null" (click)="$event.stopPropagation()">
@@ -50,18 +55,6 @@
                         (cbOnSuccess)="showTemplateCopiedNotification()">
                     <mat-icon>content_paste</mat-icon>
                 </button>
-                <span *ngIf="list.authorId === userUid && !list.isCommissionList"
-                      [matTooltipDisabled]="!anonymous"
-                      [matTooltip]="'PERMISSIONS.No_anonymous' | translate"
-                      matTooltipPosition="above">
-                    <button mat-icon-button
-                            (click)="$event.stopPropagation();openPermissions(list)"
-                            [disabled]="anonymous"
-                            [matTooltip]="'PERMISSIONS.Title' | translate"
-                            matTooltipPosition="above">
-                        <mat-icon>security</mat-icon>
-                    </button>
-                </span>
                 <button mat-icon-button *ngIf="buttons" ngxClipboard [cbContent]="getLink()"
                         (click)="$event.stopPropagation()"
                         matTooltip="{{'Share' | translate}}" matTooltipPosition="above"
@@ -75,16 +68,23 @@
                         *ngIf="list.authorId === userUid  && !list.isCommissionList">
                     <mat-icon>label_outline</mat-icon>
                 </button>
+                <span *ngIf="list.authorId === userUid && !list.isCommissionList"
+                      [matTooltipDisabled]="!anonymous"
+                      [matTooltip]="'PERMISSIONS.No_anonymous' | translate"
+                      matTooltipPosition="above">
+                    <button mat-icon-button
+                            (click)="$event.stopPropagation();openPermissions(list)"
+                            [disabled]="anonymous"
+                            [matTooltip]="'PERMISSIONS.Title' | translate"
+                            matTooltipPosition="above">
+                        <mat-icon>security</mat-icon>
+                    </button>
+                </span>
 
-                <button mat-icon-button *ngIf="buttons" routerLink="/list/{{list.$key}}"
-                        matTooltip="{{'LIST.BUTTONS.Open' | translate}}" matTooltipPosition="above"
-                        (click)="$event.stopPropagation()">
-                    <mat-icon>playlist_play</mat-icon>
-                </button>
                 <button mat-icon-button *ngIf="!readonly && buttons && list.authorId === userUid"
                         matTooltip="{{'LIST.BUTTONS.Delete' | translate}}" matTooltipPosition="above"
                         (click)="ondelete.emit(); $event.stopPropagation()">
-                    <mat-icon>delete</mat-icon>
+                    <mat-icon color="warn">delete</mat-icon>
                 </button>
                 <button mat-icon-button *ngIf="copyButton" (click)="$event.stopPropagation();forkList()"
                         [matTooltip]="'LIST.Copied_x_times' | translate:{'count': list.forks}"
@@ -101,6 +101,11 @@
                                      [isOwnList]="list.authorId === authorUid"
                                      color="null" (click)="$event.stopPropagation()">
                 </app-comments-button>
+                <button mat-icon-button *ngIf="buttons" routerLink="/list/{{list.$key}}"
+                        matTooltip="{{'LIST.BUTTONS.Open' | translate}}" matTooltipPosition="above"
+                        (click)="$event.stopPropagation()">
+                    <mat-icon>playlist_play</mat-icon>
+                </button>
                 <button mat-icon-button *ngIf="buttons && linkButton"
                         matTooltip="{{'CUSTOM_LINKS.Add_link' | translate}}" matTooltipPosition="above"
                         (click)="$event.stopPropagation(); openLinkPopup(list)">
@@ -120,18 +125,6 @@
                         (cbOnSuccess)="showTemplateCopiedNotification()">
                     <mat-icon>content_paste</mat-icon>
                 </button>
-                <span *ngIf="list.authorId === userUid"
-                      [matTooltipDisabled]="!anonymous"
-                      [matTooltip]="'PERMISSIONS.No_anonymous' | translate"
-                      matTooltipPosition="above">
-                    <button mat-icon-button
-                            (click)="$event.stopPropagation();openPermissions(list)"
-                            [disabled]="anonymous"
-                            [matTooltip]="'PERMISSIONS.Title' | translate"
-                            matTooltipPosition="above">
-                        <mat-icon>security</mat-icon>
-                    </button>
-                </span>
                 <button mat-icon-button *ngIf="buttons" ngxClipboard [cbContent]="getLink()"
                         (click)="$event.stopPropagation()"
                         matTooltip="{{'Share' | translate}}" matTooltipPosition="above"
@@ -144,16 +137,22 @@
                         (click)="openTagsPopup()" *ngIf="list.authorId === userUid">
                     <mat-icon>label_outline</mat-icon>
                 </button>
-
-                <button mat-icon-button *ngIf="buttons" routerLink="/list/{{list.$key}}"
-                        matTooltip="{{'LIST.BUTTONS.Open' | translate}}" matTooltipPosition="above"
-                        (click)="$event.stopPropagation()">
-                    <mat-icon>playlist_play</mat-icon>
-                </button>
+                <span *ngIf="list.authorId === userUid"
+                      [matTooltipDisabled]="!anonymous"
+                      [matTooltip]="'PERMISSIONS.No_anonymous' | translate"
+                      matTooltipPosition="above">
+                    <button mat-icon-button
+                            (click)="$event.stopPropagation();openPermissions(list)"
+                            [disabled]="anonymous"
+                            [matTooltip]="'PERMISSIONS.Title' | translate"
+                            matTooltipPosition="above">
+                        <mat-icon>security</mat-icon>
+                    </button>
+                </span>
                 <button mat-icon-button *ngIf="!readonly && buttons && list.authorId === userUid"
                         matTooltip="{{'LIST.BUTTONS.Delete' | translate}}" matTooltipPosition="above"
                         (click)="ondelete.emit(); $event.stopPropagation()">
-                    <mat-icon>delete</mat-icon>
+                    <mat-icon color="warn">delete</mat-icon>
                 </button>
                 <button mat-icon-button *ngIf="copyButton" (click)="$event.stopPropagation();forkList()"
                         [matTooltip]="'LIST.Copied_x_times' | translate:{'count': list.forks}"

--- a/src/app/pages/lists/lists/lists.component.html
+++ b/src/app/pages/lists/lists/lists.component.html
@@ -128,10 +128,20 @@
                         </button>
                     </mat-panel-title>
                     <div class="buttons">
+                        <button mat-icon-button routerLink="/workshop/{{workshop.$key}}"
+                                (click)="$event.stopPropagation()">
+                            <mat-icon>playlist_play</mat-icon>
+                        </button>
                         <button mat-icon-button *ngIf="userData?.patron || userData?.admin"
                                 matTooltip="{{'CUSTOM_LINKS.Add_link' | translate}}" matTooltipPosition="above"
                                 (click)="$event.stopPropagation(); openLinkPopup(workshop)">
                             <mat-icon>link</mat-icon>
+                        </button>
+                        <button mat-icon-button ngxClipboard [cbContent]="getLink(workshop)"
+                                (click)="$event.stopPropagation()"
+                                matTooltip="{{'Share' | translate}}" matTooltipPosition="above"
+                                (cbOnSuccess)="showCopiedNotification()">
+                            <mat-icon>share</mat-icon>
                         </button>
                         <span *ngIf="workshop.authorId === userData.$key"
                               [matTooltipDisabled]="!anonymous"
@@ -145,19 +155,9 @@
                                 <mat-icon>security</mat-icon>
                             </button>
                         </span>
-                        <button mat-icon-button ngxClipboard [cbContent]="getLink(workshop)"
-                                (click)="$event.stopPropagation()"
-                                matTooltip="{{'Share' | translate}}" matTooltipPosition="above"
-                                (cbOnSuccess)="showCopiedNotification()">
-                            <mat-icon>share</mat-icon>
-                        </button>
-                        <button mat-icon-button routerLink="/workshop/{{workshop.$key}}"
-                                (click)="$event.stopPropagation()">
-                            <mat-icon>playlist_play</mat-icon>
-                        </button>
                         <button mat-icon-button
                                 (click)="deleteWorkshop(workshop); $event.stopPropagation()">
-                            <mat-icon>delete</mat-icon>
+                            <mat-icon color="warn">delete</mat-icon>
                         </button>
                     </div>
                 </mat-expansion-panel-header>
@@ -206,10 +206,20 @@
                         </button>
                     </mat-panel-title>
                     <div class="buttons">
+                        <button mat-icon-button routerLink="/workshop/{{workshopData.workshop.$key}}"
+                                (click)="$event.stopPropagation()">
+                            <mat-icon>playlist_play</mat-icon>
+                        </button>
                         <button mat-icon-button *ngIf="userData?.patron || userData?.admin"
                                 matTooltip="{{'CUSTOM_LINKS.Add_link' | translate}}" matTooltipPosition="above"
                                 (click)="$event.stopPropagation(); openLinkPopup(workshopData.workshop)">
                             <mat-icon>link</mat-icon>
+                        </button>
+                        <button mat-icon-button ngxClipboard [cbContent]="getLink(workshopData.workshop)"
+                                (click)="$event.stopPropagation()"
+                                matTooltip="{{'Share' | translate}}" matTooltipPosition="above"
+                                (cbOnSuccess)="showCopiedNotification()">
+                            <mat-icon>share</mat-icon>
                         </button>
                         <span *ngIf="workshopData.workshop.authorId === userData.$key"
                               [matTooltipDisabled]="!anonymous"
@@ -223,16 +233,6 @@
                                 <mat-icon>security</mat-icon>
                             </button>
                         </span>
-                        <button mat-icon-button ngxClipboard [cbContent]="getLink(workshopData.workshop)"
-                                (click)="$event.stopPropagation()"
-                                matTooltip="{{'Share' | translate}}" matTooltipPosition="above"
-                                (cbOnSuccess)="showCopiedNotification()">
-                            <mat-icon>share</mat-icon>
-                        </button>
-                        <button mat-icon-button routerLink="/workshop/{{workshopData.workshop.$key}}"
-                                (click)="$event.stopPropagation()">
-                            <mat-icon>playlist_play</mat-icon>
-                        </button>
                     </div>
                 </mat-expansion-panel-header>
                 <div class="row workshop-row"


### PR DESCRIPTION
Moves the open button to the far left and the security & delete
buttons to the far right. This should better order the buttons from
most to least used. Also colors the delete button red, since it is
destructive.