### PR TITLE
Updated pricing mode

### DIFF
--- a/src/app/model/other/default-consumables.ts
+++ b/src/app/model/other/default-consumables.ts
@@ -5,10 +5,10 @@ import {DeserializeAs} from '@kaiu/serializer';
 export class DefaultConsumables {
 
     @DeserializeAs(Consumable)
-    food: Consumable;
+    food: Consumable = null;
 
     @DeserializeAs(Consumable)
-    medicine: Consumable;
+    medicine: Consumable = null;
 
     @DeserializeAs([FreeCompanyAction])
     freeCompanyActions: FreeCompanyAction[];

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.html
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.html
@@ -4,25 +4,26 @@
     </div>
     <p mat-line class="item-name">
         {{item.id | itemName | i18n}}
-        <mat-icon *ngIf="craftCost !== undefined" matTooltip="{{'Minimal_craft_cost' | translate}}: {{craftCost}} gil"
+        <mat-icon *ngIf="_craftCost !== undefined" matTooltip="{{'Minimal_craft_cost' | translate}}: {{_craftCost}} gil"
                  matTooltipPosition="above">
             attach_money
         </mat-icon>
-        <mat-icon color="warn" *ngIf="craftCost > 0 && (price.nq * amount.nq + price.hq * amount.hq) > 0 && !earning"
-        matTooltip="{{'PRICING.Materials_have_cost' | translate}}" matTooltipPosition="above">error_outline</mat-icon>
     </p>
 
     <mat-icon *ngIf="price.fromVendor" class="from-vendor" matTooltip="{{'PRICING.From_vendor' | translate}}"
               matTooltipPosition="above">group
     </mat-icon>
 
-    <mat-slide-toggle [(ngModel)]="item.usePrice" (change)="save.emit()">
-    </mat-slide-toggle>
+    <mat-slide-toggle [(ngModel)]="item.usePrice" (change)="save.emit()"></mat-slide-toggle>
+
+    <mat-checkbox *ngIf="preCraft" [(ngModel)]="customPrice" (change)="setAutoPrice(); saveCustomPrice()"></mat-checkbox>
+
     <div class="amount-group">
         <div class="field-group" matLine>
             <mat-form-field class="nofix price">
                 <span matPrefix>NQ &nbsp;</span>
-                <input matInput type="number" lang="en-150" min="0" [(ngModel)]="price.nq" (ngModelChange)="savePrice()">
+                <input matInput type="number" lang="en-150" min="0" [disabled]="preCraft && !customPrice"
+                    [(ngModel)]="price.nq" (ngModelChange)="savePrice()">
             </mat-form-field>
             <mat-form-field class="nofix amount">
                 <span matPrefix>x &nbsp;</span>
@@ -33,7 +34,8 @@
         <div class="field-group" matLine *ngIf="!isCrystal()">
             <mat-form-field class="nofix price">
                 <span matPrefix>HQ &nbsp;</span>
-                <input matInput type="number" lang="en-150" min="0" [(ngModel)]="price.hq" (ngModelChange)="savePrice()">
+                <input matInput type="number" lang="en-150" min="0" [disabled]="preCraft && !customPrice"
+                    [(ngModel)]="price.hq" (ngModelChange)="savePrice()">
             </mat-form-field>
             <mat-form-field class="nofix amount">
                 <span matPrefix>x &nbsp;</span>

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.html
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.html
@@ -16,7 +16,7 @@
 
     <mat-slide-toggle [(ngModel)]="item.usePrice" (change)="save.emit()"></mat-slide-toggle>
 
-    <mat-checkbox *ngIf="preCraft" [(ngModel)]="customPrice" (change)="setAutoPrice(); saveCustomPrice()"></mat-checkbox>
+    <mat-checkbox *ngIf="preCraft" [(ngModel)]="customPrice" (change)="saveCustomPrice()"></mat-checkbox>
 
     <div class="amount-group">
         <div class="field-group" matLine>

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.html
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.html
@@ -27,7 +27,7 @@
             </mat-form-field>
             <mat-form-field class="nofix amount">
                 <span matPrefix>x &nbsp;</span>
-                <input matInput type="number" lang="en-150" min="0" max="{{item.amount}}" [readonly]="isCrystal()"
+                <input matInput type="number" min="0" [max]="item.amount" [readonly]="isCrystal()"
                     [(ngModel)]="amount.nq" (ngModelChange)="changeNQ()">
             </mat-form-field>
         </div>
@@ -39,7 +39,7 @@
             </mat-form-field>
             <mat-form-field class="nofix amount">
                 <span matPrefix>x &nbsp;</span>
-                <input matInput type="number" lang="en-150" min="0" max="{{item.amount}}"
+                <input matInput type="number" lang="en-150" min="0" [max]="item.amount"
                     [(ngModel)]="amount.hq" (ngModelChange)="changeHQ()">
             </mat-form-field>
         </div>

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.html
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.html
@@ -4,8 +4,9 @@
     </div>
     <p mat-line class="item-name">
         {{item.id | itemName | i18n}}
-        <mat-icon *ngIf="_craftCost !== undefined" matTooltip="{{'Minimal_craft_cost' | translate}}: {{_craftCost}} gil"
-                 matTooltipPosition="above">
+        <mat-icon *ngIf="_craftCost !== undefined"
+            matTooltip="{{'Minimal_craft_cost' | translate}}: {{_craftCost * item.amount}} gil"
+            matTooltipPosition="above">
             attach_money
         </mat-icon>
     </p>

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.html
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.html
@@ -22,21 +22,23 @@
         <div class="field-group" matLine>
             <mat-form-field class="nofix price">
                 <span matPrefix>NQ &nbsp;</span>
-                <input matInput type="number" lang="en-150" [(ngModel)]="price.nq" (ngModelChange)="savePrice()">
+                <input matInput type="number" lang="en-150" min="0" [(ngModel)]="price.nq" (ngModelChange)="savePrice()">
             </mat-form-field>
             <mat-form-field class="nofix amount">
                 <span matPrefix>x &nbsp;</span>
-                <input matInput type="number" lang="en-150" [(ngModel)]="amount.nq" (ngModelChange)="saveAmount()">
+                <input matInput type="number" lang="en-150" min="0" max="{{item.amount}}" [readonly]="isCrystal()"
+                    [(ngModel)]="amount.nq" (ngModelChange)="changeNQ()">
             </mat-form-field>
         </div>
         <div class="field-group" matLine *ngIf="!isCrystal()">
             <mat-form-field class="nofix price">
                 <span matPrefix>HQ &nbsp;</span>
-                <input matInput type="number" lang="en-150" [(ngModel)]="price.hq" (ngModelChange)="savePrice()">
+                <input matInput type="number" lang="en-150" min="0" [(ngModel)]="price.hq" (ngModelChange)="savePrice()">
             </mat-form-field>
             <mat-form-field class="nofix amount">
                 <span matPrefix>x &nbsp;</span>
-                <input matInput type="number" lang="en-150" [(ngModel)]="amount.hq" (ngModelChange)="saveAmount()">
+                <input matInput type="number" lang="en-150" min="0" max="{{item.amount}}"
+                    [(ngModel)]="amount.hq" (ngModelChange)="changeHQ()">
             </mat-form-field>
         </div>
     </div>

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.html
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.html
@@ -5,7 +5,7 @@
     <p mat-line class="item-name">
         {{item.id | itemName | i18n}}
         <mat-icon *ngIf="_craftCost !== undefined"
-            matTooltip="{{'Minimal_craft_cost' | translate}}: {{_craftCost * item.amount}} gil"
+            matTooltip="{{'Minimal_craft_cost' | translate}}: {{_craftCost | number:'1.0-0'}} gil"
             matTooltipPosition="above">
             attach_money
         </mat-icon>

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.scss
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.scss
@@ -5,7 +5,7 @@
     }
 
     .amount {
-        width: 40px;
+        width: 80px;
     }
 
     .item-name {

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.scss
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.scss
@@ -33,4 +33,8 @@
             margin-left: 20px;
         }
     }
+
+    .mat-checkbox {
+        margin-left: 10px;
+    }
 }

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.scss
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.scss
@@ -5,7 +5,7 @@
     }
 
     .amount {
-        width: 80px;
+        width: 60px;
     }
 
     .item-name {

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.ts
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.ts
@@ -23,9 +23,7 @@ export class PricingRowComponent implements OnInit {
     @Input()
     public set craftCost(cost: number) {
         this._craftCost = cost;
-        if (this.preCraft && !this.customPrice) {
-            this.price.nq = this.price.hq = cost;
-        }
+        this.setAutoCost();
     }
 
     @Input()
@@ -62,11 +60,13 @@ export class PricingRowComponent implements OnInit {
     }
 
     changeNQ(): void {
+        this.amount.nq = Math.min(this.amount.nq, this.item.amount);
         this.amount.hq = this.item.amount - this.amount.nq;
         this.saveAmount();
     }
 
     changeHQ(): void {
+        this.amount.hq = Math.min(this.amount.hq, this.item.amount);
         this.amount.nq = this.item.amount - this.amount.hq;
         this.saveAmount();
     }
@@ -81,9 +81,7 @@ export class PricingRowComponent implements OnInit {
             this.price = this.pricingService.getEarnings(this.item);
         } else {
             this.price = this.pricingService.getPrice(this.item);
-            if (this.preCraft && !this.customPrice) {
-                this.price.nq = this.price.hq = this._craftCost;
-            }
+            this.setAutoCost();
         }
         this.amount = this.pricingService.getAmount(this.listId, this.item, this.earning);
         if (this.item.usePrice === undefined) {
@@ -95,4 +93,9 @@ export class PricingRowComponent implements OnInit {
         return this.media.isActive('sm') || this.media.isActive('xs');
     }
 
+    private setAutoCost(): void {
+        if (this.preCraft && !this.customPrice) {
+            this.price.nq = this.price.hq = this._craftCost;
+        }
+    }
 }

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.ts
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.ts
@@ -45,6 +45,16 @@ export class PricingRowComponent implements OnInit {
         this.pricingService.savePrice(this.item, this.price);
     }
 
+    changeNQ(): void {
+        this.amount.hq = this.item.amount - this.amount.nq;
+        this.saveAmount();
+    }
+
+    changeHQ(): void {
+        this.amount.nq  = this.item.amount - this.amount.hq;
+        this.saveAmount();
+    }
+
     saveAmount(): void {
         this.pricingService.saveAmount(this.listId, this.item, this.amount);
     }

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.ts
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.ts
@@ -18,16 +18,26 @@ export class PricingRowComponent implements OnInit {
     @Input()
     listId: string;
 
+    private _craftCost: number;
+
     @Input()
-    craftCost: number;
+    public set craftCost(cost: number) {
+        this._craftCost = cost;
+        this.setAutoPrice();
+    }
 
     @Input()
     earning = false;
 
     @Input()
+    preCraft = false;
+
+    @Input()
     odd = false;
 
     price: Price;
+
+    customPrice = false;
 
     amount: ItemAmount;
 
@@ -43,6 +53,16 @@ export class PricingRowComponent implements OnInit {
 
     savePrice(): void {
         this.pricingService.savePrice(this.item, this.price);
+    }
+
+    setAutoPrice(): void {
+        if (this.preCraft && !this.customPrice) {
+            this.price.nq = this.price.hq = this._craftCost / this.item.amount;
+        }
+    }
+
+    saveCustomPrice(): void {
+        this.pricingService.saveCustomPrice(this.item, this.customPrice);
     }
 
     changeNQ(): void {
@@ -64,7 +84,9 @@ export class PricingRowComponent implements OnInit {
             this.price = this.pricingService.getEarnings(this.item);
         } else {
             this.price = this.pricingService.getPrice(this.item);
+            this.setAutoPrice();
         }
+        this.customPrice = this.pricingService.isCustomPrice(this.item);
         this.amount = this.pricingService.getAmount(this.listId, this.item, this.earning);
         if (this.item.usePrice === undefined) {
             this.item.usePrice = true;

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.ts
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.ts
@@ -95,7 +95,7 @@ export class PricingRowComponent implements OnInit {
 
     private setAutoCost(): void {
         if (this.preCraft && !this.customPrice) {
-            this.price.nq = this.price.hq = this._craftCost;
+            this.price.nq = this.price.hq = Math.ceil(this._craftCost);
         }
     }
 }

--- a/src/app/modules/pricing/pricing-row/pricing-row.component.ts
+++ b/src/app/modules/pricing/pricing-row/pricing-row.component.ts
@@ -18,12 +18,14 @@ export class PricingRowComponent implements OnInit {
     @Input()
     listId: string;
 
-    private _craftCost: number;
+    public _craftCost: number;
 
     @Input()
     public set craftCost(cost: number) {
         this._craftCost = cost;
-        this.setAutoPrice();
+        if (this.preCraft && !this.customPrice) {
+            this.price.nq = this.price.hq = cost;
+        }
     }
 
     @Input()
@@ -55,12 +57,6 @@ export class PricingRowComponent implements OnInit {
         this.pricingService.savePrice(this.item, this.price);
     }
 
-    setAutoPrice(): void {
-        if (this.preCraft && !this.customPrice) {
-            this.price.nq = this.price.hq = this._craftCost / this.item.amount;
-        }
-    }
-
     saveCustomPrice(): void {
         this.pricingService.saveCustomPrice(this.item, this.customPrice);
     }
@@ -71,7 +67,7 @@ export class PricingRowComponent implements OnInit {
     }
 
     changeHQ(): void {
-        this.amount.nq  = this.item.amount - this.amount.hq;
+        this.amount.nq = this.item.amount - this.amount.hq;
         this.saveAmount();
     }
 
@@ -80,13 +76,15 @@ export class PricingRowComponent implements OnInit {
     }
 
     ngOnInit(): void {
+        this.customPrice = this.pricingService.isCustomPrice(this.item);
         if (this.earning) {
             this.price = this.pricingService.getEarnings(this.item);
         } else {
             this.price = this.pricingService.getPrice(this.item);
-            this.setAutoPrice();
+            if (this.preCraft && !this.customPrice) {
+                this.price.nq = this.price.hq = this._craftCost;
+            }
         }
-        this.customPrice = this.pricingService.isCustomPrice(this.item);
         this.amount = this.pricingService.getAmount(this.listId, this.item, this.earning);
         if (this.item.usePrice === undefined) {
             this.item.usePrice = true;

--- a/src/app/modules/pricing/pricing.module.ts
+++ b/src/app/modules/pricing/pricing.module.ts
@@ -5,6 +5,7 @@ import {PricingService} from './pricing.service';
 import {
     MatButtonModule,
     MatCardModule,
+    MatCheckboxModule,
     MatExpansionModule,
     MatIconModule,
     MatInputModule,
@@ -24,6 +25,7 @@ import {PipesModule} from '../../pipes/pipes.module';
         CommonModule,
 
         MatCardModule,
+        MatCheckboxModule,
         MatExpansionModule,
         MatListModule,
         MatInputModule,

--- a/src/app/modules/pricing/pricing.service.ts
+++ b/src/app/modules/pricing/pricing.service.ts
@@ -16,9 +16,15 @@ export class PricingService {
      */
     private amounts: { [index: string]: { [index: number]: ItemAmount } };
 
+    /**
+     * Array of custom prices
+     */
+    private customPrices: [number];
+
     constructor() {
         this.prices = this.parsePrices(localStorage.getItem('prices'));
         this.amounts = JSON.parse(localStorage.getItem('amounts')) || {};
+        this.customPrices = JSON.parse(localStorage.getItem('customPrices')) || [];
     }
 
     /**
@@ -73,6 +79,23 @@ export class PricingService {
     savePrice(item: ListRow, price: Price): void {
         this.prices[item.id] = price;
         this.persistPrices();
+    }
+
+    /**
+     * Saves an item as having a custom price
+     * @param {ListRow} item
+     * @param {boolean} customPrice
+     */
+    saveCustomPrice(item: ListRow, customPrice: boolean): void {
+        const index = this.customPrices.indexOf(item.id);
+
+        if (customPrice && index === -1) {
+            this.customPrices.push(item.id);
+        } else if (!customPrice && index !== -1) {
+            this.customPrices.splice(index, 1);
+        }
+
+        this.persistCustomPrice();
     }
 
     /**
@@ -144,10 +167,26 @@ export class PricingService {
     }
 
     /**
+     * Gets whether or not the item has a custom price set
+     * @param {ListRow} item
+     * @returns {boolean}
+     */
+    isCustomPrice(item: ListRow): boolean {
+        return this.customPrices.indexOf(item.id) !== -1;
+    }
+
+    /**
      * Persists the current prices to localStorage.
      */
     private persistPrices(): void {
         localStorage.setItem('prices', this.stringifyPrices(this.prices));
+    }
+
+    /**
+     * Persists the custom prices to localStorage.
+     */
+    private persistCustomPrice(): void {
+        localStorage.setItem('customPrices', JSON.stringify(this.customPrices));
     }
 
     /**

--- a/src/app/modules/pricing/pricing/pricing.component.html
+++ b/src/app/modules/pricing/pricing/pricing.component.html
@@ -14,7 +14,6 @@
     <mat-expansion-panel *ngIf="list.crystals.length > 0">
         <mat-expansion-panel-header>
             <mat-panel-title>{{"Crystals" | translate}}</mat-panel-title>
-            <mat-panel-description>{{getTotalPrice(list.crystals)}} gil</mat-panel-description>
         </mat-expansion-panel-header>
         <mat-list dense>
             <app-pricing-row *ngFor="let item of list.crystals; let odd = odd" (save)="save()" [item]="item"
@@ -26,7 +25,6 @@
     <mat-expansion-panel *ngIf="list.gathers.length > 0">
         <mat-expansion-panel-header>
             <mat-panel-title>{{"Gathering" | translate}}</mat-panel-title>
-            <mat-panel-description>{{getTotalPrice(list.gathers).toLocaleString()}} gil</mat-panel-description>
         </mat-expansion-panel-header>
         <mat-list dense>
             <app-pricing-row *ngFor="let item of list.gathers; let odd = odd" (save)="save()" [item]="item"
@@ -38,7 +36,6 @@
     <mat-expansion-panel *ngIf="list.others.length > 0">
         <mat-expansion-panel-header>
             <mat-panel-title>{{"Other" | translate}}</mat-panel-title>
-            <mat-panel-description>{{getTotalPrice(list.others).toLocaleString()}} gil</mat-panel-description>
         </mat-expansion-panel-header>
         <mat-list dense>
             <app-pricing-row *ngFor="let item of list.others; let odd = odd" (save)="save()" [item]="item"
@@ -50,13 +47,12 @@
     <mat-expansion-panel *ngIf="list.preCrafts.length > 0">
         <mat-expansion-panel-header>
             <mat-panel-title>{{"Pre_crafts" | translate}}</mat-panel-title>
-            <mat-panel-description>{{getTotalPrice(list.preCrafts).toLocaleString()}} gil</mat-panel-description>
         </mat-expansion-panel-header>
         <mat-list dense>
             <app-pricing-row *ngFor="let item of list.preCrafts; let odd = odd" (save)="save()" [item]="item"
                              [listId]="list.$key"
                              [odd]="odd"
-                             [craftCost]="getCraftCost(item)"></app-pricing-row>
+                             [craftCost]="getCraftCost(item)" [preCraft]="true"></app-pricing-row>
         </mat-list>
     </mat-expansion-panel>
 

--- a/src/app/modules/pricing/pricing/pricing.component.html
+++ b/src/app/modules/pricing/pricing/pricing.component.html
@@ -56,7 +56,7 @@
                              [item]="item"
                              [listId]="list.$key"
                              [odd]="odd"
-                             [craftCost]="getCraftCost(item) / item.amount_needed"
+                             [craftCost]="getCraftCost(item) / item.amount"
                              [preCraft]="true"></app-pricing-row>
         </mat-list>
     </mat-expansion-panel>

--- a/src/app/modules/pricing/pricing/pricing.component.html
+++ b/src/app/modules/pricing/pricing/pricing.component.html
@@ -70,7 +70,8 @@
         <app-pricing-row *ngFor="let item of list.recipes; trackBy: trackByItemFn; let odd = odd;" (save)="save()"
                          [item]="item"
                          [listId]="list.$key" [odd]="odd"
-                         [craftCost]="getCraftCost(item)" [earning]="true"></app-pricing-row>
+                         [craftCost]="getCraftCost(item) / item.amount"
+                         [earning]="true"></app-pricing-row>
     </mat-list>
 </mat-card>
 

--- a/src/app/modules/pricing/pricing/pricing.component.html
+++ b/src/app/modules/pricing/pricing/pricing.component.html
@@ -56,7 +56,8 @@
                              [item]="item"
                              [listId]="list.$key"
                              [odd]="odd"
-                             [craftCost]="getCraftCost(item)" [preCraft]="true"></app-pricing-row>
+                             [craftCost]="getCraftCost(item) / item.amount_needed"
+                             [preCraft]="true"></app-pricing-row>
         </mat-list>
     </mat-expansion-panel>
 

--- a/src/app/modules/pricing/pricing/pricing.component.html
+++ b/src/app/modules/pricing/pricing/pricing.component.html
@@ -16,7 +16,8 @@
             <mat-panel-title>{{"Crystals" | translate}}</mat-panel-title>
         </mat-expansion-panel-header>
         <mat-list dense>
-            <app-pricing-row *ngFor="let item of list.crystals; let odd = odd" (save)="save()" [item]="item"
+            <app-pricing-row *ngFor="let item of list.crystals; trackBy: trackByItemFn; let odd = odd;" (save)="save()"
+                             [item]="item"
                              [listId]="list.$key"
                              [odd]="odd"></app-pricing-row>
         </mat-list>
@@ -27,7 +28,8 @@
             <mat-panel-title>{{"Gathering" | translate}}</mat-panel-title>
         </mat-expansion-panel-header>
         <mat-list dense>
-            <app-pricing-row *ngFor="let item of list.gathers; let odd = odd" (save)="save()" [item]="item"
+            <app-pricing-row *ngFor="let item of list.gathers; trackBy: trackByItemFn; let odd = odd;" (save)="save()"
+                             [item]="item"
                              [listId]="list.$key"
                              [odd]="odd"></app-pricing-row>
         </mat-list>
@@ -38,7 +40,8 @@
             <mat-panel-title>{{"Other" | translate}}</mat-panel-title>
         </mat-expansion-panel-header>
         <mat-list dense>
-            <app-pricing-row *ngFor="let item of list.others; let odd = odd" (save)="save()" [item]="item"
+            <app-pricing-row *ngFor="let item of list.others; trackBy: trackByItemFn; let odd = odd;" (save)="save()"
+                             [item]="item"
                              [listId]="list.$key"
                              [odd]="odd"></app-pricing-row>
         </mat-list>
@@ -49,7 +52,8 @@
             <mat-panel-title>{{"Pre_crafts" | translate}}</mat-panel-title>
         </mat-expansion-panel-header>
         <mat-list dense>
-            <app-pricing-row *ngFor="let item of list.preCrafts; let odd = odd" (save)="save()" [item]="item"
+            <app-pricing-row *ngFor="let item of list.preCrafts; trackBy: trackByItemFn; let odd = odd;" (save)="save()"
+                             [item]="item"
                              [listId]="list.$key"
                              [odd]="odd"
                              [craftCost]="getCraftCost(item)" [preCraft]="true"></app-pricing-row>
@@ -62,7 +66,8 @@
     <mat-card-title>{{"Earning" | translate}}</mat-card-title>
     <mat-card-subtitle>{{getTotalEarnings(list.recipes).toLocaleString()}} gil</mat-card-subtitle>
     <mat-list dense>
-        <app-pricing-row *ngFor="let item of list.recipes; let odd = odd" (save)="save()" [item]="item"
+        <app-pricing-row *ngFor="let item of list.recipes; trackBy: trackByItemFn; let odd = odd;" (save)="save()"
+                         [item]="item"
                          [listId]="list.$key" [odd]="odd"
                          [craftCost]="getCraftCost(item)" [earning]="true"></app-pricing-row>
     </mat-list>

--- a/src/app/modules/pricing/pricing/pricing.component.ts
+++ b/src/app/modules/pricing/pricing/pricing.component.ts
@@ -61,8 +61,8 @@ export class PricingComponent {
         }
         return row.requires.reduce((total, requirement) => {
             const requirementRow = this.list.getItemById(requirement.id, true);
-            const amount = Math.ceil(requirement.amount / requirementRow.yield);
-            return total + this.getCraftCost(requirementRow, amount * amountNeeded);
+            const amount = Math.ceil((requirement.amount * amountNeeded) / requirementRow.yield);
+            return total + this.getCraftCost(requirementRow, amount);
         }, 0);
     }
 

--- a/src/app/modules/pricing/pricing/pricing.component.ts
+++ b/src/app/modules/pricing/pricing/pricing.component.ts
@@ -92,4 +92,8 @@ export class PricingComponent {
     getBenefits(): number {
         return this.getTotalEarnings(this.list.recipes) - this.getSpendingTotal();
     }
+
+    public trackByItemFn(index: number, item: ListRow): number {
+        return item.id;
+    }
 }

--- a/src/app/modules/pricing/pricing/pricing.component.ts
+++ b/src/app/modules/pricing/pricing/pricing.component.ts
@@ -70,7 +70,7 @@ export class PricingComponent {
     }
 
     /**
-     * Gets the minimum crafting cost of a given item.
+     * Gets the crafting cost of a given item.
      * @param {ListRow} row
      * @returns {number}
      */
@@ -83,26 +83,7 @@ export class PricingComponent {
             }
             const price = this.pricingService.getPrice(listRow);
             const amount = this.pricingService.getAmount(this.list.$key, listRow);
-            // We're gona get the lowest possible price.
-            let needed = row.amount_needed * requirement.amount;
-            // First of all, we get the maximum of nq items;
-            if (needed <= amount.nq) {
-                total += needed * price.nq;
-            } else {
-                // If we don't have enough nq items, we take what we already have.
-                total += amount.nq * price.nq;
-                needed -= amount.nq;
-                // Then we check for hq items
-                if (needed <= amount.hq) {
-                    // If we have enough of them, we can simply add them
-                    total += needed * price.hq;
-                } else {
-                    // Else, we assume that the crafter already has some items in his inventory,
-                    // that's why he didn't add them in the pricing.
-                    // So we'll assume the remaining items are free.
-                    total += amount.hq * price.hq;
-                }
-            }
+            total += amount.nq * price.nq + amount.hq * price.hq;
         });
         return total;
     }

--- a/src/app/modules/pricing/pricing/pricing.component.ts
+++ b/src/app/modules/pricing/pricing/pricing.component.ts
@@ -35,10 +35,7 @@ export class PricingComponent {
      * @returns {number}
      */
     getSpendingTotal(): number {
-        return this.getTotalPrice(this.list.crystals) +
-            this.getTotalPrice(this.list.gathers) +
-            this.getTotalPrice(this.list.others) +
-            this.getTotalPrice(this.list.preCrafts);
+        return this.list.recipes.reduce((total, item) => total + this.getCraftCost(item), 0);
     }
 
     /**

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -556,8 +556,7 @@
     }
   },
   "PRICING": {
-    "From_vendor": "Price from vendor",
-    "Materials_have_cost": "Materials for this craft have cost > 0, make sure you're not counting them twice"
+    "From_vendor": "Price from vendor"
   },
   "COMMISSION_BOARD": {
     "Title": "Commission board",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -551,8 +551,7 @@
     }
   },
   "PRICING": {
-    "From_vendor": "Precio del vendedor",
-    "Materials_have_cost": "Los materiales para esta elaboración tienen costos > a 0, asegúrese de no estar contandolos doble"
+    "From_vendor": "Precio del vendedor"
   },
   "COMMISSION_BOARD": {
     "Title": "Tablero de comisiones",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -559,8 +559,7 @@
     }
   },
   "PRICING": {
-    "From_vendor": "Prix au vendeur",
-    "Materials_have_cost": "Des matériaux pour ce craft ont un prix supérieur à 0, soyez sûr de ne pas les compter deux fois"
+    "From_vendor": "Prix au vendeur"
   },
   "COMMISSION_BOARD": {
     "Title": "Tableau de requêtes",


### PR DESCRIPTION
Resolves #515 by implementing the features 4 & 5 it requested. Features 1-3 already exist and are set to remain in place.

The cost of pre-crafts is now determined automatically by the sum of their materials costs. A checkbox has been added that will allow the users to select it and enter a custom amount if they wish to override this value.

Totals for each individual panel in pricing mode have been removed, as the spending logic has changed. Now instead of summing each of these totals, we recursively sum the costs of each material required for the final recipes. This also removes the "materials have cost" warning.

Adds automatic balancing to the item amounts. For example, if a recipe requires 8 of an item, you can have 5 NQ and 3 HQ. Increasing the NQ to 6 will automatically decrease the HQ to 2.

Also includes a fix for the display of crafting books, courtesy of @Supamiu. 😄

