### PR TITLE
feat: commission board history

### DIFF
--- a/src/app/pages/commission-board/commission-board.module.ts
+++ b/src/app/pages/commission-board/commission-board.module.ts
@@ -19,6 +19,7 @@ import {CommissionChatComponent} from './commission-chat/commission-chat.compone
 import {RatingPopupComponent} from './rating-popup/rating-popup.component';
 import {HistoryComponent} from './history/history.component';
 import {RatingComponent} from './rating/rating.component';
+import {ServerHistoryComponent} from './server-history/server-history.component';
 import {
     MatBadgeModule,
     MatButtonModule,
@@ -58,6 +59,10 @@ const routes: Routes = [
             {
                 path: 'history',
                 component: HistoryComponent,
+            },
+            {
+                path: 'server-history',
+                component: ServerHistoryComponent,
             }
         ]
     },
@@ -114,7 +119,8 @@ const routes: Routes = [
         CommissionChatComponent,
         RatingPopupComponent,
         HistoryComponent,
-        RatingComponent
+        RatingComponent,
+        ServerHistoryComponent
     ],
     entryComponents: [
         CommissionCreationPopupComponent,

--- a/src/app/pages/commission-board/commission-board/commission-board.component.ts
+++ b/src/app/pages/commission-board/commission-board/commission-board.component.ts
@@ -70,6 +70,11 @@ export class CommissionBoardComponent {
                     }),
                 )
         },
+        {
+            path: 'server-history',
+            label: 'COMMISSION_BOARD.Server_history',
+            hasNewThings: of(false)
+        }
     ];
 
     constructor(private userService: UserService, private commissionService: CommissionService) {

--- a/src/app/pages/commission-board/commission-panel/commission-panel.component.html
+++ b/src/app/pages/commission-board/commission-panel/commission-panel.component.html
@@ -16,8 +16,8 @@
             </span>
         </mat-panel-description>
         <mat-chip-list>
-            <mat-chip selectable="false" color="accent" selected>{{('COMMISSION_BOARD.STATUS.' + getStatus(commission))
-                | translate}}
+            <mat-chip *ngIf="isActive(commission)" selectable="false" color="accent" selected>
+                {{('COMMISSION_BOARD.STATUS.' + getStatus(commission)) | translate}}
             </mat-chip>
             <mat-chip selectable="false" *ngIf="commission.onlyNeedsCraft">{{'COMMISSION_BOARD.TAGS.Only_craft' |
                 translate}}

--- a/src/app/pages/commission-board/commission-panel/commission-panel.component.ts
+++ b/src/app/pages/commission-board/commission-panel/commission-panel.component.ts
@@ -91,6 +91,10 @@ export class CommissionPanelComponent implements OnInit {
         return CommissionStatus[commission.status];
     }
 
+    public isActive(commission: Commission): boolean {
+        return commission.status !== CommissionStatus.DONE;
+    }
+
     ngOnInit(): void {
         this.author$ = this.userService.getCharacter(this.commission.authorId);
         this.user$ = this.userService.getUserData();

--- a/src/app/pages/commission-board/history/history.component.ts
+++ b/src/app/pages/commission-board/history/history.component.ts
@@ -19,24 +19,25 @@ export class HistoryComponent {
         const myRequests$ = this.userService.getCharacter()
             .pipe(
                 mergeMap(character => {
-                    return this.commissionService.getAll(character.server, ref => ref.where('authorId', '==', character.userId))
-                        .pipe(
-                            map(commissions => commissions.filter(com => com.status === CommissionStatus.DONE))
-                        );
+                    return this.commissionService.getAll(character.server, ref =>
+                        ref.where('authorId', '==', character.userId)
+                           .where('status', '==', CommissionStatus.DONE)
+                    )
                 })
             );
         const myCrafts$ = this.userService.getCharacter()
             .pipe(
                 mergeMap(character => {
-                    return this.commissionService.getAll(character.server, ref => ref.where('crafterId', '==', character.userId))
-                        .pipe(
-                            map(commissions => commissions.filter(com => com.status === CommissionStatus.DONE))
-                        );
+                    return this.commissionService.getAll(character.server, ref =>
+                        ref.where('crafterId', '==', character.userId)
+                           .where('status', '==', CommissionStatus.DONE)
+                    )
                 })
             );
         this.commissions$ = combineLatest(myRequests$, myCrafts$)
             .pipe(
-                map(results => [...results[0], ...results[1]])
+                map(results => [...results[0], ...results[1]]),
+                map(results => results.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()))
             )
     }
 

--- a/src/app/pages/commission-board/server-history/server-history.component.html
+++ b/src/app/pages/commission-board/server-history/server-history.component.html
@@ -1,0 +1,12 @@
+<div *ngIf="commissions$ | async as commissions; else loading">
+    <div *ngIf="commissions.length === 0" class="no-commissions">
+        {{'COMMISSION_BOARD.No_history' | translate}}
+    </div>
+    <app-commission-panel [commission]="commission"
+                          *ngFor="let commission of commissions; trackBy: trackByCommissionFn"></app-commission-panel>
+</div>
+<ng-template #loading>
+    <div class="loader-container">
+        <mat-spinner></mat-spinner>
+    </div>
+</ng-template>

--- a/src/app/pages/commission-board/server-history/server-history.component.scss
+++ b/src/app/pages/commission-board/server-history/server-history.component.scss
@@ -1,0 +1,9 @@
+.no-commissions {
+    font-size: 40px;
+    width: 100%;
+    min-height: 300px;
+    opacity: .7;
+    align-items: center;
+    display: flex;
+    justify-content: center;
+}

--- a/src/app/pages/commission-board/server-history/server-history.component.ts
+++ b/src/app/pages/commission-board/server-history/server-history.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit } from '@angular/core';
+import {Observable} from 'rxjs/index';
+import {Commission} from '../../../model/commission/commission';
+import {CommissionStatus} from '../../../model/commission/commission-status';
+import {mergeMap} from 'rxjs/operators';
+import {UserService} from '../../../core/database/user.service';
+import {CommissionService} from '../../../core/database/commission/commission.service';
+
+@Component({
+  selector: 'app-server-history',
+  templateUrl: './server-history.component.html',
+  styleUrls: ['./server-history.component.scss']
+})
+export class ServerHistoryComponent {
+
+public commissions$: Observable<Commission[]>;
+
+    constructor(private commissionService: CommissionService, private userService: UserService) {
+        this.commissions$ = this.userService.getCharacter()
+            .pipe(
+                mergeMap(character => {
+                    return this.commissionService.getAll(character.server, ref =>
+                        ref.where('status', '==', CommissionStatus.DONE)
+                           .orderBy('createdAt', 'desc')
+                           .limit(50)
+                    )
+                })
+        );
+    }
+
+    trackByCommissionFn(index: number, commission: Commission): string {
+        return commission.$key;
+    }
+}

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -530,6 +530,7 @@
     "My_requests": "Meine Inserate",
     "My_crafts": "Meine aktiven Aufträge",
     "History": "Archiviert",
+    "Server_history": "serverweite Historie",
     "No_commissions": "Keine offenen Inserate auf deinem Server",
     "Chat_warning": "Bitte gib deine Logindaten niemals im Chat weiter, niemand sollte jemals danach fragen. Die Nutzung des Chats als Platform für RMT resultiert in einer permanenten Sperre auf der Webseite und einer Weiterleitung des Falls an Square Enix.",
     "Chat_placeholder": "Neue Nachricht senden",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -566,6 +566,7 @@
     "My_requests": "My requests",
     "My_crafts": "My ongoing commissions",
     "History": "Archived",
+    "Server_history": "Server history",
     "No_commissions": "No opened commissions on your server",
     "Chat_warning": "Remember to never give your credentials in the chat, nobody should ask for them. Using this chat to use the platform for RMT will result in a permanent ban from the website and the case forwarded to Square Enix",
     "Chat_placeholder": "Send new message",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -569,6 +569,7 @@
     "My_requests": "Mes requêtes",
     "My_crafts": "Mes commissions",
     "History": "Archives",
+    "Server_history": "Historique du serveur",
     "No_commissions": "Pas de requêtes sur votre serveur",
     "Chat_warning": "Pensez bien à ne jamais donner d'identifiants par le chat. Toute utilisation afin de conclure un arrangement de type RMT sera puni d'un ban du site et d'une transmission des preuves à Square Enix.",
     "Chat_placeholder": "Envoyer un message",


### PR DESCRIPTION
Adds another tab to the commission board where users can view the
previous commissions archived for their server. Updates the commission
panel to hide the Archived tag, since it is redundant. Updates the
archived commission fetch to query the status from Firestore and sort
the results in descending date order.

Resolves #519