### PR TITLE
fix(simulator): Fix actions being placed into wrong spots

### DIFF
--- a/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -436,7 +436,7 @@
                 </div>
                 <div class="action-drag-zone" droppable
                      dragOverClass="drag-over"
-                     (onDrop)="moveSkill($event.dragData, resultData.simulation.steps.length - 1); tooltipsDisabled = false"></div>
+                     (onDrop)="moveSkill($event.dragData, resultData.simulation.steps.length); tooltipsDisabled = false"></div>
             </div>
         </mat-card>
         <mat-card>

--- a/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -548,7 +548,19 @@ export class SimulatorComponent implements OnInit, OnDestroy {
         const actions = this.actions$.getValue();
         // If the data is a number, use it as index
         if (+dragData === dragData) {
-            actions.splice(targetIndex, 0, actions.splice(dragData, 1)[0]);
+            let movedAction = actions[dragData]
+
+            if (dragData < targetIndex) {
+                for (let i = dragData; i < targetIndex - 1; i++) {
+                    actions[i] = actions[i + 1]
+                }
+                actions[targetIndex - 1] = movedAction
+            } else {
+                for (let i = dragData - 1; i >= targetIndex; i--) {
+                    actions[i + 1] = actions[i]
+                }
+                actions[targetIndex] = movedAction
+            }
         } else if (dragData instanceof CraftingAction) {
             actions.splice(targetIndex, 0, dragData);
         }


### PR DESCRIPTION
Change drag-and-drop logic to manually move part of the array between the old and new position.
Should also be a bit faster than 2 splices.

Closes #552