### PR TITLE
fix: new rotation button not displaying

### DIFF
--- a/src/app/pages/simulator/components/rotations-page/rotations-page.component.html
+++ b/src/app/pages/simulator/components/rotations-page/rotations-page.component.html
@@ -66,7 +66,7 @@
     <ng-template #noRotations>
         <span class="no-rotations">{{'SIMULATOR.No_rotations' | translate}}</span>
     </ng-template>
-    <button class="new-rotation" (click)="newRotation()" mat-raised-button color="accent">
-        {{'SIMULATOR.New_rotation' | translate}}
-    </button>
 </div>
+<button class="new-rotation" (click)="newRotation()" mat-raised-button color="accent">
+    {{'SIMULATOR.New_rotation' | translate}}
+</button>


### PR DESCRIPTION
The new rotation button was not displaying for guest users, where the
rotations observable was not returning data. The display of the new
rotation button should not be dependent on the rotations data, so it has
been moved outside of the div that was checking for it.