### PR TITLE
feat: starting quality

### DIFF
--- a/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -138,7 +138,12 @@
             </div>
         </div>
         <div class="config-row" *ngIf="!customMode">
-            <h3>{{'SIMULATOR.CONFIGURATION.Ingredients' | translate}}</h3>
+            <h3 class="ingredients">
+                {{'SIMULATOR.CONFIGURATION.Ingredients' | translate}}<br>
+                <i *ngIf="startingQuality$ | async as startingQuality">
+                    {{startingQuality}}
+                </i>
+            </h3>
             <mat-list>
                 <mat-list-item *ngFor="let ingredient of hqIngredientsData">
                     <span matLine [appXivdbTooltip]="ingredient.id">{{ingredient.id | itemName | i18n}}</span>

--- a/src/app/pages/simulator/components/simulator/simulator.component.scss
+++ b/src/app/pages/simulator/components/simulator/simulator.component.scss
@@ -34,6 +34,10 @@
     }
 }
 
+.ingredients {
+    margin-bottom: 0;
+}
+
 .steps {
     white-space: nowrap;
     font-size: 1.2rem;

--- a/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -162,8 +162,11 @@ export class SimulatorComponent implements OnInit, OnDestroy {
         new BehaviorSubject<{ id: number, amount: number }[]>([]);
 
     @Input()
-    public set hqIngredients(ingredients: { id: number, amount: number }[]) {
+    public set hqIngredients(ingredients: { id: number, amount: number, quality: number }[]) {
         this.hqIngredients$.next(ingredients);
+        this.startingQuality$.next(ingredients.reduce((total, ingredient) => {
+            return total += ingredient.amount * ingredient.quality;
+        }, 0));
     }
 
     @Input()
@@ -199,6 +202,8 @@ export class SimulatorComponent implements OnInit, OnDestroy {
     }
 
     public hqIngredientsData: { id: number, amount: number, max: number, quality: number }[] = [];
+
+    public startingQuality$: BehaviorSubject<number> = new BehaviorSubject(0);
 
     public foods: Consumable[] = [];
 
@@ -518,7 +523,7 @@ export class SimulatorComponent implements OnInit, OnDestroy {
                 authorId: this.authorId,
                 consumables: { food: this._selectedFood, medicine: this._selectedMedicine },
                 freeCompanyActions: this._selectedFreeCompanyActions,
-                folder: this.rotation.folder
+                folder: this.rotation === undefined ? '' : this.rotation.folder
             });
         } else {
             this.onsave.emit(<CustomCraftingRotation>{
@@ -530,7 +535,7 @@ export class SimulatorComponent implements OnInit, OnDestroy {
                 authorId: this.authorId,
                 consumables: { food: this._selectedFood, medicine: this._selectedMedicine },
                 freeCompanyActions: this._selectedFreeCompanyActions,
-                folder: this.rotation.folder
+                folder: this.rotation === undefined ? '' : this.rotation.folder
             });
         }
         if (asNew) {


### PR DESCRIPTION
Displays the starting quality in the ingredients panel after HQ
ingredients have been selected. Also fixes a bug where new rotations
could not be saved.

Resolves #591