### PR TITLE
fix: consumable styles

### DIFF
--- a/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -170,7 +170,7 @@
             </div>
             <div class="consumables">
                 <div layout="row">
-                    <div class="foods" flex="50">
+                    <div class="foods">
                         <mat-select [(ngModel)]="_selectedFood"
                                     placeholder="{{'SIMULATOR.CONFIGURATION.Food' | translate}}">
                             <mat-option [value]="undefined"></mat-option>
@@ -190,7 +190,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="medicines" flex="50">
+                    <div class="medicines">
                         <mat-select [(ngModel)]="_selectedMedicine"
                                     placeholder="{{'SIMULATOR.CONFIGURATION.Medicine' | translate}}">
                             <mat-option [value]="undefined"></mat-option>

--- a/src/app/pages/simulator/components/simulator/simulator.component.scss
+++ b/src/app/pages/simulator/components/simulator/simulator.component.scss
@@ -102,6 +102,10 @@
             display: flex;
             > div {
                 margin: 10px;
+                width: 100%;
+            }
+            > .foods, .medicines {
+                width: 50%;
             }
         }
     }


### PR DESCRIPTION
Fixes incorrect flexing on consumable styles where the widths were incorrect and the placeholder text was not being displayed.

**Before:**
![image](https://user-images.githubusercontent.com/1176304/46384551-ac177000-c684-11e8-8b5a-9c429a28f046.png)

**After:**
![image](https://user-images.githubusercontent.com/1176304/46384561-c05b6d00-c684-11e8-97e5-615ebcb62c52.png)
