### PR TITLE
feat: convert custom rotation to normal rotation

### DIFF
--- a/src/app/pages/simulator/components/custom-simulator-page/custom-simulator-page.component.ts
+++ b/src/app/pages/simulator/components/custom-simulator-page/custom-simulator-page.component.ts
@@ -100,6 +100,8 @@ export class CustomSimulatorPageComponent {
                     result.rotation = rotation.rotation;
                     result.stats = rotation.stats;
                     result.recipe = rotation.recipe;
+                    result.defaultItemId = rotation.defaultItemId;
+                    result.defaultRecipeId = rotation.defaultRecipeId;
                     result.authorId = rotation.authorId;
                     result.description = '';
                     result.name = rotation.name;
@@ -118,7 +120,13 @@ export class CustomSimulatorPageComponent {
                     }
                 })
             ).subscribe((rotationKey) => {
-            this.router.navigate(['simulator', 'custom', rotationKey]);
+                if (rotation.defaultItemId) {
+                    // If the rotation has a default item ID, it has been converted to a normal rotation, so navigate there
+                    this.router.navigate(['simulator', rotation.defaultItemId, rotation.defaultRecipeId, rotationKey]);
+                } else {
+                    // Otherwise it is a custom rotation
+                    this.router.navigate(['simulator', 'custom', rotationKey]);
+                }
         });
     }
 

--- a/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -13,6 +13,13 @@
         <mat-icon>save</mat-icon>
     </button>
     <button mat-mini-fab
+            matTooltip="{{'SIMULATOR.Convert_rotation' | translate}}"
+            matTooltipPosition="{{isMobile()?'below':'right'}}"
+            *ngIf="customMode && (actions$ | async).length > 0 && authorId === userData?.$key"
+            (click)="convertRotation()">
+        <mat-icon>redo</mat-icon>
+    </button>
+    <button mat-mini-fab
             matTooltip="{{'SIMULATOR.Reset' | translate}}"
             matTooltipPosition="{{isMobile()?'below':'right'}}"
             *ngIf="(actions$ | async).length > 0" (click)="clearRotation()">

--- a/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -559,7 +559,7 @@ export class SimulatorComponent implements OnInit, OnDestroy {
                         authorId: this.authorId,
                         consumables: { food: this._selectedFood, medicine: this._selectedMedicine },
                         freeCompanyActions: this._selectedFreeCompanyActions,
-                        folder: ''
+                        folder: this.rotation === undefined ? '' : this.rotation.folder
                     });
                 })
             });

--- a/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -543,6 +543,29 @@ export class SimulatorComponent implements OnInit, OnDestroy {
         }
     }
 
+    convertRotation(): void {
+        this.dialog.open(RecipeChoicePopupComponent).afterClosed()
+            .pipe(
+                filter(res => res !== undefined && res !== null && res !== '')
+            ).subscribe(result => {
+                this.dataService.getItem(result.itemId).subscribe(item => {
+                    this.onsave.emit({
+                        $key: this.rotation.$key,
+                        name: this.rotation.name,
+                        rotation: this.serializedRotation,
+                        recipe: item.getCraft(result.recipeId),
+                        defaultItemId: result.itemId,
+                        defaultRecipeId: result.recipeId,
+                        authorId: this.authorId,
+                        consumables: { food: this._selectedFood, medicine: this._selectedMedicine },
+                        freeCompanyActions: this._selectedFreeCompanyActions,
+                        folder: ''
+                    });
+                })
+            });
+
+    }
+
     getStars(nb: number): string {
         return this.htmlTools.generateStars(nb);
     }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -483,6 +483,7 @@
 	"Save_as_new": "Als neue Rotation speichern (bringt dich zur neu erstellten Rotation)",
     "Save_as_new_done": "Du arbeitest jetzt auf einer Kopie deiner Rotation",
     "Change_rotation": "Rotation wechseln",
+    "Convert_rotation": "Zu Standardrotation konvertieren",
     "New_rotation_folder": "Neuer Ordner",
     "CUSTOM": {
       "Recipe_configuration": "Einstellungen für Rezept",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -485,6 +485,7 @@
     "Save_as_new": "Save as new (navigates to the newly created rotation)",
     "Save_as_new_done": "You're now on a copy of your rotation",
     "Change_rotation": "Change rotation",
+    "Convert_rotation": "Convert to a standard rotation",
     "New_rotation_folder": "New folder",
     "CUSTOM": {
       "Recipe_configuration": "Recipe configuration",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -485,6 +485,7 @@
     "Save_as_new": "Guardar como (navega a la nueva rotation creada)",
     "Save_as_new_done": "Usted está ahora en una copia de su rotación",
     "Change_rotation": "Escoger rotación",
+    "Convert_rotation": "Convertir a rotación estándar",
     "New_rotation_folder": "Nueva carpeta",
     "CUSTOM": {
       "Recipe_configuration": "Configuración de receta",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -485,6 +485,7 @@
     "Save_as_new": "Sauvergarder une copie (navigue sur la copie de la rotation)",
     "Save_as_new_done": "Vous êtes maintenant sur la copie de votre rotation",
     "Change_rotation": "Changer de rotation",
+    "Convert_rotation": "Convertir en rotation standard",
     "New_rotation_folder": "Nouveau dossier",
     "CUSTOM": {
       "Recipe_configuration": "Configuration de la recette",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -114,6 +114,7 @@
   },
   "SIMULATOR": {
     "Average_hq": "平均HQ",
+    "Convert_rotation": "普通スキル回しに変えます",
     "CATEGORY": {
       "Buff": "バフ",
       "Cp_recovery": "CPを回復",


### PR DESCRIPTION
Adds a button to the Simulator page that allows users to convert a saved
custom rotation into a normal rotation. This is done by allowing the
user to search for a recipe to use for the rotation, and then saving
that item/recipe with the rotation so it is opened like a normal one.

Resolves #609