### PR TITLE
Fix Byregot's Miracle

### DIFF
--- a/src/app/pages/simulator/model/actions/quality/byregots-miracle.ts
+++ b/src/app/pages/simulator/model/actions/quality/byregots-miracle.ts
@@ -14,16 +14,15 @@ export class ByregotsMiracle extends QualityAction {
     }
 
     execute(simulation: Simulation): void {
-        // Don't add stack now, We'll add it manually after the reduction is done.
+        // Even though this is a quality action, it should not add a stack
         super.execute(simulation, true);
-        // Divides stacks by 2, but adds one because it increased progression (done by QualityAction implementation)
-        simulation.getBuff(Buff.INNER_QUIET).stacks = Math.floor(simulation.getBuff(Buff.INNER_QUIET).stacks / 2);
-        simulation.getBuff(Buff.INNER_QUIET).stacks++;
+        // Stacks are divided by 2 and rounded up
+        simulation.getBuff(Buff.INNER_QUIET).stacks = Math.ceil(simulation.getBuff(Buff.INNER_QUIET).stacks / 2);
     }
 
     onFail(simulation: Simulation): void {
         // Stacks are still reduces upon failing.
-        simulation.getBuff(Buff.INNER_QUIET).stacks = Math.floor(simulation.getBuff(Buff.INNER_QUIET).stacks / 2)
+        simulation.getBuff(Buff.INNER_QUIET).stacks = Math.ceil(simulation.getBuff(Buff.INNER_QUIET).stacks / 2)
     }
 
     getBaseCPCost(simulationState: Simulation): number {

--- a/src/index.html
+++ b/src/index.html
@@ -3470,7 +3470,8 @@
             'C\'elosia Arcanine',
             'Coconut Koala (Diabolos)',
             'Pumpkin Spice Lattes',
-            'Pint Sized Mafia'
+            'Pint Sized Mafia',
+            'Nunosi Ior'
         ];
         const randomPatron = patrons[Math.floor(Math.random() * patrons.length)];
         document.getElementById('random-patron').innerText = randomPatron;


### PR DESCRIPTION
Previously it was adding a stack of Inner Quiet, but that should not be happening. The stacks should also be rounded up after the division.