### PR TITLE
refactor: character link server

### DIFF
--- a/apps/client/src/app/core/auth/character-link-popup/character-link-popup.component.ts
+++ b/apps/client/src/app/core/auth/character-link-popup/character-link-popup.component.ts
@@ -37,15 +37,15 @@ export class CharacterLinkPopupComponent {
       map(servers => {
         return [
           ...servers,
-          'Korean server'
-        ];
+          'Korean Server'
+        ].sort();
       })
     );
 
     this.autoCompleteRows$ = combineLatest(this.servers$, this.selectedServer.valueChanges)
       .pipe(
         map(([servers, inputValue]) => {
-          return servers.filter(server => server.indexOf(inputValue) > -1);
+          return servers.filter(server => server.toLowerCase().indexOf(inputValue.toLowerCase()) > -1);
         })
       );
 


### PR DESCRIPTION
Makes the server autocomplete in the character link popup case insensitive. Capitalizes "Korean Server" for consistency and ensures the servers are sorted alphabetically.