### PR TITLE
fix(simulator): dragging the last action doesn't make it immovable

### DIFF
--- a/apps/client/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/apps/client/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -425,9 +425,9 @@
           <i nz-icon type="exclamation-circle" theme="twotone" [twoToneColor]="'#aa9400'" class="warning-icon"
              nz-tooltip [nzTitle]="'SIMULATOR.Unsaved_changes' | translate" *ngIf="dirty"></i>
           <div fxLayout="row wrap" ngxDroppable="action" fxLayoutGap="10px" class="actions-container ngx-dnd-container"
-               (drop)="actionDrop($event)">
+               (drop)="actionDrop($event)" (cancel)="dragCancel($event)">
             <div *ngFor="let step of resultData.steps;let i = index;" [ngxDraggable]="['action']"
-                 class="ngx-dnd-item action-container" [model]="step.action" (drag)="removeAction(i)"
+                 class="ngx-dnd-item action-container" [model]="step.action" (drag)="actionDrag(i)" 
                  [moves]="step.action.canBeMoved()">
               <app-action [action]="step.action"
                           [simulation]="resultData.simulation"

--- a/apps/client/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/apps/client/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -503,7 +503,6 @@ export class SimulatorComponent implements OnInit, OnDestroy {
   }
 
   addAction(action: CraftingAction, index?: number) {
-    console.log("action added");
     if (index === undefined) {
       this.actions$.next([...this.actions$.value, action]);
     } else {

--- a/apps/client/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/apps/client/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -94,6 +94,10 @@ export class SimulatorComponent implements OnInit, OnDestroy {
 
   public actions$ = new BehaviorSubject<CraftingAction[]>([]);
 
+  private draggedAction$: CraftingAction;
+
+  private draggedIndex$: number;
+
   public crafterStats$: Observable<CrafterStats>;
 
   public stats$: Observable<CrafterStats>;
@@ -499,6 +503,7 @@ export class SimulatorComponent implements OnInit, OnDestroy {
   }
 
   addAction(action: CraftingAction, index?: number) {
+    console.log("action added");
     if (index === undefined) {
       this.actions$.next([...this.actions$.value, action]);
     } else {
@@ -509,11 +514,26 @@ export class SimulatorComponent implements OnInit, OnDestroy {
     this.dirty = true;
   }
 
+  actionDrag(index: number): void {
+    this.draggedAction$ = this.actions$.value[index];
+    this.draggedIndex$ = index;
+    this.removeAction(index);
+  }
+
   actionDrop(event: any): void {
     if (event.el.parentNode.classList.contains('actions-container')) {
       event.el.parentNode.removeChild(event.el);
     }
     this.addAction(event.value, event.dropIndex);
+    this.draggedAction$ = null;
+  }
+  
+  dragCancel(event: any): void {
+    if (event.el.parentNode.classList.contains('actions-container')) {
+      event.el.parentNode.removeChild(event.el);
+    }
+    this.addAction(this.draggedAction$, this.draggedIndex$);
+    this.draggedAction$ = null;
   }
 
   removeAction(index: number): void {


### PR DESCRIPTION
This fixes the issue with drag-n-drop on the simulator.

In some cases the user is still unable to drop properly with error `ERROR DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.` but it seems like an unrelated issue from the library itself